### PR TITLE
Reduce `typing` imports

### DIFF
--- a/hallo/destination.py
+++ b/hallo/destination.py
@@ -1,5 +1,4 @@
 import time
-from typing import Optional
 
 from hallo.permission_mask import PermissionMask
 from abc import ABCMeta
@@ -361,7 +360,7 @@ class User(Destination):
             self.memberships_list = set()
             """:type : set[ChannelMembership]"""
 
-    def rights_check(self, right_name: str, channel_obj: Optional[Channel] = None) -> bool:
+    def rights_check(self, right_name: str, channel_obj: Channel | None = None) -> bool:
         """
         Checks the value of the right with the specified name. Returns boolean
         :param right_name: Name of the user right to check

--- a/hallo/events.py
+++ b/hallo/events.py
@@ -2,7 +2,7 @@ import enum
 import logging
 from abc import ABCMeta
 from datetime import datetime
-from typing import Any, Union, Optional, TYPE_CHECKING, Type
+from typing import Any, Optional, TYPE_CHECKING, Type
 
 if TYPE_CHECKING:
     from hallo.hallo import Hallo
@@ -627,7 +627,7 @@ class EventMessageWithPhoto(EventMessage):
             channel: Optional['Channel'],
             user: 'User',
             text: str,
-            photo_id: Union[str, list[str]],
+            photo_id: str | list[str],
             inbound: bool = True,
             *,
             menu_buttons: list[list[MenuButton]] = None

--- a/hallo/events.py
+++ b/hallo/events.py
@@ -2,7 +2,7 @@ import enum
 import logging
 from abc import ABCMeta
 from datetime import datetime
-from typing import List, Dict, Any, Union, Optional, TYPE_CHECKING, Type, Tuple
+from typing import Any, Union, Optional, TYPE_CHECKING, Type
 
 if TYPE_CHECKING:
     from hallo.hallo import Hallo
@@ -20,23 +20,23 @@ KEY_PHOTO_ID = "photo_id"
 FLAG_MENU_UNCHANGED = object()
 
 
-def server_from_json(hallo_obj: 'Hallo', data: Dict) -> 'Server':
+def server_from_json(hallo_obj: 'Hallo', data: dict) -> 'Server':
     return hallo_obj.get_server_by_name(data[KEY_SERVER_NAME])
 
 
-def channel_from_json(server: 'Server', data: Dict) -> Optional['Channel']:
+def channel_from_json(server: 'Server', data: dict) -> Optional['Channel']:
     if data[KEY_CHANNEL_ADDR]:
         return server.get_channel_by_address(data[KEY_CHANNEL_ADDR])
     return None
 
 
-def user_from_json(server: 'Server', data: Dict) -> Optional['User']:
+def user_from_json(server: 'Server', data: dict) -> Optional['User']:
     if data[KEY_USER_ADDR]:
         return server.get_user_by_address(data[KEY_USER_ADDR])
     return None
 
 
-def menu_buttons_from_json(data: Dict) -> Optional[List[List['MenuButton']]]:
+def menu_buttons_from_json(data: dict) -> Optional[list[list['MenuButton']]]:
     if KEY_MENU_BUTTONS not in data:
         return None
     return [
@@ -46,7 +46,7 @@ def menu_buttons_from_json(data: Dict) -> Optional[List[List['MenuButton']]]:
     ]
 
 
-def event_from_json(hallo_obj: 'Hallo', data: Dict) -> 'ChannelUserTextEvent':
+def event_from_json(hallo_obj: 'Hallo', data: dict) -> 'ChannelUserTextEvent':
     server = server_from_json(hallo_obj, data)
     channel = channel_from_json(server, data)
     user = user_from_json(server, data)
@@ -61,7 +61,7 @@ def event_from_json(hallo_obj: 'Hallo', data: Dict) -> 'ChannelUserTextEvent':
     return message_from_json(hallo_obj, data)
 
 
-def message_from_json(hallo_obj: 'Hallo', data: Dict) -> 'EventMessage':
+def message_from_json(hallo_obj: 'Hallo', data: dict) -> 'EventMessage':
     server = server_from_json(hallo_obj, data)
     channel = channel_from_json(server, data)
     user = user_from_json(server, data)
@@ -117,7 +117,6 @@ class RawDataTelegramOutbound(RawData):
     def __init__(self, sent_msg_object: 'Message') -> None:
         """
         :param sent_msg_object: Sent message object returned when sending message on telegram
-        :type sent_msg_object: ??
         """
         self.sent_msg_object = sent_msg_object
 
@@ -136,7 +135,7 @@ class Event(metaclass=ABCMeta):
         """
         return None
 
-    def _get_log_extras(self) -> List[Dict[str, Any]]:
+    def _get_log_extras(self) -> list[dict[str, Any]]:
         return []
 
     def log(self) -> None:
@@ -186,7 +185,7 @@ class ServerEvent(Event, metaclass=ABCMeta):
             return self.raw_data.update_obj.message.date
         return super().get_send_time()
 
-    def _get_log_extras(self) -> List[Dict[str, Any]]:
+    def _get_log_extras(self) -> list[dict[str, Any]]:
         return [
             {
                 "server": self.server
@@ -218,7 +217,7 @@ class UserEvent(ServerEvent, metaclass=ABCMeta):
     def user_addr(self) -> Optional[str]:
         return self.user.address if self.user else None
 
-    def _get_log_extras(self) -> List[Dict[str, Any]]:
+    def _get_log_extras(self) -> list[dict[str, Any]]:
         channel_list = (
             self.user.get_channel_list()
             if self.is_inbound
@@ -273,7 +272,7 @@ class ChannelEvent(ServerEvent, metaclass=ABCMeta):
     def channel_addr(self):
         return self.channel.address if self.channel else None
 
-    def _get_log_extras(self) -> List[Dict[str, Any]]:
+    def _get_log_extras(self) -> list[dict[str, Any]]:
         return [
             {
                 "server": self.server,
@@ -287,7 +286,7 @@ class ChannelUserEvent(ChannelEvent, UserEvent, metaclass=ABCMeta):
         ChannelEvent.__init__(self, server, channel, inbound=inbound)
         UserEvent.__init__(self, server, user, inbound=inbound)
 
-    def _get_log_extras(self) -> List[Dict[str, Any]]:
+    def _get_log_extras(self) -> list[dict[str, Any]]:
         return [
             {
                 "server": self.server,
@@ -363,19 +362,11 @@ class EventKick(ChannelUserEvent):
             inbound: bool = True
     ) -> None:
         """
-        :type server: server.Server
-        :type channel: destination.Channel
         :param kicking_user: User which sent the kick event, or None if outbound
-        :type kicking_user: destination.User | None
-        :type kicked_user: destination.User
-        :type kick_message: str | None
-        :type inbound: bool
         """
         ChannelUserEvent.__init__(self, server, channel, kicking_user, inbound=inbound)
-        self.kicked_user = kicked_user
-        """ :type : Destination.User"""
-        self.kick_message = kick_message
-        """:type : str | None"""
+        self.kicked_user: User = kicked_user
+        self.kick_message: str | None = kick_message
 
     def get_log_line(self) -> str:
         output = "{} was kicked from {} by {}".format(
@@ -464,7 +455,7 @@ class ChannelUserTextEvent(ChannelUserEvent, metaclass=ABCMeta):
         """
         self.server.reply(self, event)
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             KEY_SERVER_NAME: self.server_name,
             KEY_CHANNEL_ADDR: self.channel_addr,
@@ -479,14 +470,14 @@ class MenuButton:
         self.text = text
         self.data = data
 
-    def to_json(self) -> Dict[str, str]:
+    def to_json(self) -> dict[str, str]:
         return {
             "text": self.text,
             "data": self.data
         }
 
     @classmethod
-    def from_json(cls, data: Dict) -> 'MenuButton':
+    def from_json(cls, data: dict) -> 'MenuButton':
         return MenuButton(
             data["text"],
             data["data"]
@@ -512,7 +503,7 @@ class EventMessage(ChannelUserTextEvent):
             text: str,
             inbound: bool = True,
             *,
-            menu_buttons: List[List['MenuButton']] = None
+            menu_buttons: list[list['MenuButton']] = None
     ) -> None:
         """
         :param user: User who sent the event, or None for outbound to channel
@@ -543,7 +534,7 @@ class EventMessage(ChannelUserTextEvent):
     def has_photo(self) -> bool:
         return False
 
-    def check_prefix(self) -> Tuple[Union[bool, str], Optional[str]]:
+    def check_prefix(self) -> tuple[Union[bool, str], Optional[str]]:
         """
         Checks whether prefix was given, and if so, parses it out of command text.
         :return: Returns whether prefix is given, and command text
@@ -579,7 +570,7 @@ class EventMessage(ChannelUserTextEvent):
             self,
             text: str,
             event_class: Optional['EventMessage'] = None,
-            menu_buttons: Optional[List[List[MenuButton]]] = None
+            menu_buttons: Optional[list[list[MenuButton]]] = None
     ) -> 'EventMessage':
         if event_class is None:
             event_class = self.__class__
@@ -589,7 +580,7 @@ class EventMessage(ChannelUserTextEvent):
     def create_edit(
             self,
             text: Optional[str] = None,
-            menu_buttons: Optional[List[List[MenuButton]]] = FLAG_MENU_UNCHANGED
+            menu_buttons: Optional[list[list[MenuButton]]] = FLAG_MENU_UNCHANGED
     ) -> 'EventMessage':
         if text is None:
             text = self.text
@@ -599,7 +590,7 @@ class EventMessage(ChannelUserTextEvent):
         edit._message_id = self.message_id
         return edit
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         data = super().to_json()
         data[KEY_FORMATTING] = self.formatting.name
         data["message_id"] = self.message_id
@@ -639,18 +630,13 @@ class EventMessageWithPhoto(EventMessage):
             channel: Optional['Channel'],
             user: 'User',
             text: str,
-            photo_id: Union[str, List[str]],
+            photo_id: Union[str, list[str]],
             inbound: bool = True,
             *,
-            menu_buttons: List[List[MenuButton]] = None
+            menu_buttons: list[list[MenuButton]] = None
     ) -> None:
         """
-        :type server: server.Server
-        :type channel: destination.Channel | None
         :param user: User who sent the event, or None for outbound to channel
-        :type user: destination.User | None
-        :type text: str
-        :type photo_id: Union[str, List[str]]
         """
         super().__init__(server, channel, user, text, inbound=inbound, menu_buttons=menu_buttons)
         self.photo_id = photo_id
@@ -658,7 +644,7 @@ class EventMessageWithPhoto(EventMessage):
     def create_edit(
             self,
             text: Optional[str] = None,
-            menu_buttons: Optional[List[List[MenuButton]]] = FLAG_MENU_UNCHANGED
+            menu_buttons: Optional[list[list[MenuButton]]] = FLAG_MENU_UNCHANGED
     ) -> 'EventMessage':
         if text is None:
             text = self.text
@@ -679,7 +665,7 @@ class EventMessageWithPhoto(EventMessage):
     def has_photo(self) -> bool:
         return True
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         data = super().to_json()
         data[KEY_PHOTO_ID] = self.photo_id
         return data

--- a/hallo/events.py
+++ b/hallo/events.py
@@ -129,10 +129,7 @@ class Event(metaclass=ABCMeta):
     def get_send_time(self) -> datetime:
         return self.send_time
 
-    def get_log_line(self) -> Optional[str]:
-        """
-        :rtype: Optional[str]
-        """
+    def get_log_line(self) -> str | None:
         return None
 
     def _get_log_extras(self) -> list[dict[str, Any]]:
@@ -145,7 +142,7 @@ class Event(metaclass=ABCMeta):
         for extra in self._get_log_extras():
             chat_logger.info(self.get_log_line(), extra=extra)
 
-    def get_print_line(self) -> Optional[str]:
+    def get_print_line(self) -> str | None:
         return None
 
 
@@ -214,7 +211,7 @@ class UserEvent(ServerEvent, metaclass=ABCMeta):
         self.user = user
 
     @property
-    def user_addr(self) -> Optional[str]:
+    def user_addr(self) -> str | None:
         return self.user.address if self.user else None
 
     def _get_log_extras(self) -> list[dict[str, Any]]:
@@ -309,7 +306,7 @@ class EventJoin(ChannelUserEvent):
             server: 'Server',
             channel: 'Channel',
             user: 'User',
-            password: Optional[str] = None,
+            password: str | None = None,
             inbound: bool = True
     ):
         """
@@ -332,7 +329,7 @@ class EventLeave(ChannelUserEvent):
             server: 'Server',
             channel: 'Channel',
             user: 'User',
-            message: Optional[str],
+            message: str | None,
             inbound: bool = True
     ) -> None:
         """
@@ -358,7 +355,7 @@ class EventKick(ChannelUserEvent):
             channel: 'Channel',
             kicking_user: Optional['User'],
             kicked_user: 'User',
-            kick_message: Optional[str],
+            kick_message: str | None,
             inbound: bool = True
     ) -> None:
         """
@@ -519,7 +516,7 @@ class EventMessage(ChannelUserTextEvent):
         self._message_id = None
 
     @property
-    def message_id(self) -> Optional[int]:
+    def message_id(self) -> int | None:
         if isinstance(self.raw_data, RawDataTelegram):
             return self.raw_data.update_obj.message.message_id
         if isinstance(self.raw_data, RawDataTelegramOutbound):
@@ -534,7 +531,7 @@ class EventMessage(ChannelUserTextEvent):
     def has_photo(self) -> bool:
         return False
 
-    def check_prefix(self) -> tuple[Union[bool, str], Optional[str]]:
+    def check_prefix(self) -> tuple[bool | str, str | None]:
         """
         Checks whether prefix was given, and if so, parses it out of command text.
         :return: Returns whether prefix is given, and command text
@@ -579,8 +576,8 @@ class EventMessage(ChannelUserTextEvent):
 
     def create_edit(
             self,
-            text: Optional[str] = None,
-            menu_buttons: Optional[list[list[MenuButton]]] = FLAG_MENU_UNCHANGED
+            text: str | None = None,
+            menu_buttons: list[list[MenuButton]] | None = FLAG_MENU_UNCHANGED
     ) -> 'EventMessage':
         if text is None:
             text = self.text
@@ -643,8 +640,8 @@ class EventMessageWithPhoto(EventMessage):
 
     def create_edit(
             self,
-            text: Optional[str] = None,
-            menu_buttons: Optional[list[list[MenuButton]]] = FLAG_MENU_UNCHANGED
+            text: str | None = None,
+            menu_buttons: list[list[MenuButton]] | None = FLAG_MENU_UNCHANGED
     ) -> 'EventMessage':
         if text is None:
             text = self.text

--- a/hallo/function.py
+++ b/hallo/function.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Set, Type, Optional
+from typing import Type
 
 from hallo.events import (
     EventSecond,
@@ -56,7 +56,7 @@ class Function(ABC):
 
     def __init__(self):
         self.help_name = None  # Name for use in help listing
-        self.names: Set[str] = set()  # Set of names which can be used to address the function
+        self.names: set[str] = set()  # Set of names which can be used to address the function
         self.help_docs = (
             None  # Help documentation, if it's just a single line, can be set here
         )
@@ -83,11 +83,11 @@ class Function(ABC):
         """Saves the function, persistent functions only."""
         return None
 
-    def get_passive_events(self) -> Set[Type[Event]]:
+    def get_passive_events(self) -> set[Type[Event]]:
         """Returns a list of events which this function may want to respond to in a passive way"""
         return set()
 
-    def passive_run(self, event: Event, hallo_obj) -> Optional[ServerEvent]:
+    def passive_run(self, event: Event, hallo_obj) -> ServerEvent | None:
         """Replies to an event not directly addressed to the bot.
         :param event: Event which has called the function
         :param hallo_obj: Hallo object which fired the event.
@@ -108,7 +108,7 @@ class Function(ABC):
             raise NotImplementedError
         return self.help_docs
 
-    def get_names(self) -> Set[str]:
+    def get_names(self) -> set[str]:
         """Returns the list of names for directly addressing the function"""
         self.names.add(self.help_name)
         return self.names

--- a/hallo/function_dispatcher.py
+++ b/hallo/function_dispatcher.py
@@ -5,7 +5,7 @@ import re
 import sys
 import inspect
 from types import ModuleType
-from typing import Set, Type, Dict, Optional, List, TypeVar
+from typing import Type, TypeVar, TYPE_CHECKING
 
 from prometheus_client import Counter
 
@@ -27,6 +27,10 @@ from hallo.events import (
 from hallo.function import Function
 from hallo.inc.commons import inherits_from
 from hallo.server import Server
+
+if TYPE_CHECKING:
+    from hallo.hallo import Hallo
+
 
 logger = logging.getLogger(__name__)
 FuncT = TypeVar("FuncT", bound=Function)
@@ -72,22 +76,22 @@ class FunctionDispatcher(object):
     """
     MODULE_DIR = "hallo/modules"
 
-    def __init__(self, module_list: Set[str], hallo):
+    def __init__(self, module_list: set[str], hallo: "Hallo"):
         """
         Constructor
         :type module_list: set[str]
         :type hallo: hallo.Hallo
         """
         self.hallo = hallo  # Hallo object which owns this
-        self.module_list: Set[str] = module_list  # List of available module names
+        self.module_list: set[str] = module_list  # List of available module names
         self.function_dict = (
             {}
         )  # Dictionary of moduleObjects->functionClasses->namesList/eventsList
-        self.function_names: Dict[str, Type[Function]] = {}  # Dictionary of names -> functionClasses
-        self.persistent_functions: Dict[Type[Function], Function] = (
+        self.function_names: dict[str, Type[Function]] = {}  # Dictionary of names -> functionClasses
+        self.persistent_functions: dict[Type[Function], Function] = (
             {}
         )  # Dictionary of persistent function objects. functionClass->functionObject
-        self.event_functions: Dict[Type[Event], Set[Type[Function]]] = (
+        self.event_functions: dict[Type[Event], set[Type[Function]]] = (
             {}
         )  # Dictionary with events classes as keys and sets of function classes
         #  (which may want to act on those events) as values
@@ -95,7 +99,7 @@ class FunctionDispatcher(object):
         for module_name in self.module_list:
             self.reload_module(module_name)
 
-    def dispatch(self, event: EventMessage, flag_list: List[str] = None) -> None:
+    def dispatch(self, event: EventMessage, flag_list: list[str] = None) -> None:
         """
         Sends the function call out to whichever function, if one is found
         :param event: The message event which has triggered the function dispatch
@@ -212,7 +216,7 @@ class FunctionDispatcher(object):
                 passive_errors.labels(function_class=function_class.__name__).inc()
                 continue
 
-    def get_function_by_name(self, function_name: str) -> Optional[Type[Function]]:
+    def get_function_by_name(self, function_name: str) -> Type[Function] | None:
         """
         Find a functionClass by a name specified by a user. Not functionClass.__name__
         :param function_name: Name of the function to search for
@@ -227,7 +231,7 @@ class FunctionDispatcher(object):
             return self.function_names[function_name]
         return None
 
-    def get_function_class_list(self) -> List[Type[Function]]:
+    def get_function_class_list(self) -> list[Type[Function]]:
         """Returns a simple flat list of all function classes."""
         function_class_list = []
         for module_object in self.function_dict:
@@ -246,7 +250,7 @@ class FunctionDispatcher(object):
         return function_obj
 
     def check_function_permissions(
-        self, function_class: Type[Function], server_obj: Server, user_obj: User, channel_obj: Optional[Channel]
+        self, function_class: Type[Function], server_obj: Server, user_obj: User, channel_obj: Channel | None
     ) -> bool:
         """Checks if a function can be called. Returns boolean, True if allowed
         :param function_class: Class of function to check permissions for
@@ -289,7 +293,7 @@ class FunctionDispatcher(object):
             success = success and self.reload_python_module(full_module_name)
         return success
 
-    def list_modules_in_package(self, package_name: str) -> List[str]:
+    def list_modules_in_package(self, package_name: str) -> list[str]:
         return [
             x[:-3] for x in os.listdir(f"{self.MODULE_DIR}/{package_name}")
             if x.endswith(".py") and not x.startswith("__")
@@ -460,7 +464,7 @@ class FunctionDispatcher(object):
         # Remove from mFunctionDict
         del self.function_dict[module_obj][function_class]
 
-    def list_cross_module_imports(self, module_name: str) -> List[str]:
+    def list_cross_module_imports(self, module_name: str) -> list[str]:
         full_module_names = self.full_module_names_for_module(module_name)
         cross_module_import = re.compile(r"import hallo\.modules\.([^.\s]+)")
         other_modules = set()
@@ -473,7 +477,7 @@ class FunctionDispatcher(object):
         other_modules.discard(module_name)
         return list(other_modules)
 
-    def full_module_names_for_module(self, module_name: str) -> List[str]:
+    def full_module_names_for_module(self, module_name: str) -> list[str]:
         if os.path.isfile(f"{self.MODULE_DIR}/{module_name}.py"):
             # It's a python module
             logger.debug("Reloading module")
@@ -490,9 +494,9 @@ class FunctionDispatcher(object):
     def close(self) -> None:
         """Shut down FunctionDispatcher, save all functions, etc"""
         for module_object in list(self.function_dict):
-            self.unload_module_functions(module_object)
+            self.unload_module_functi(module_object)
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         """
         Output the function dispatcher configuration in a dict format for saving as json
         """

--- a/hallo/function_dispatcher.py
+++ b/hallo/function_dispatcher.py
@@ -501,14 +501,3 @@ class FunctionDispatcher(object):
         for module_name in self.module_list:
             json_obj["modules"].append({"name": module_name})
         return json_obj
-
-    @staticmethod
-    def from_json(json_obj: Dict, hallo) -> 'FunctionDispatcher':
-        """
-        Creates a function dispatcher from json object dict
-        """
-        module_list = set()
-        for module in json_obj["modules"]:
-            module_list.add(module["name"])
-        new_dispatcher = FunctionDispatcher(module_list, hallo)
-        return new_dispatcher

--- a/hallo/hallo.py
+++ b/hallo/hallo.py
@@ -4,7 +4,6 @@ import logging
 import re
 import time
 from datetime import datetime
-from typing import Union, Set, Dict, Optional
 
 import heartbeat
 from prometheus_client import start_http_server
@@ -44,21 +43,30 @@ class Hallo:
     CONFIG_FILE = "config/config.json"
     CONFIG_DEFAULT_FILE = "config/config-default.json"
 
-    def __init__(self):
-        self.default_nick: str = "Hallo"
-        self.default_prefix: Union[bool, str] = False
-        self.default_full_name: str = "HalloBot HalloHost HalloServer :an irc bot by spangle"
+    def __init__(
+            self,
+            *,
+            default_nick: str = "Hallo",
+            default_prefix: bool | str = False,
+            default_full_name: str = "HalloBot HalloHost HalloServer :an irc bot by spangle",
+            function_dispatcher_modules: set | None = None,
+    ) -> None:
+        self.default_nick: str = default_nick
+        self.default_prefix: bool | str = default_prefix
+        self.default_full_name: str = default_full_name
         self.open: bool = False
-        self.user_group_list: Set[UserGroup] = set()
-        self.server_list: Set[Server] = set()
-        self.api_key_list: Dict[str, str] = {}
+        self.user_group_list: set[UserGroup] = set()
+        self.server_list: set[Server] = set()
+        self.api_key_list: dict[str, str] = {}
         self.server_factory: ServerFactory = ServerFactory(self)
         self.permission_mask: PermissionMask = PermissionMask()
         self.prom_port = 7265
         server_count.set_function(lambda: len(self.server_list))
         server_connected_count.set_function(lambda: len([s for s in self.server_list.copy() if s.is_connected()]))
-        # TODO: manual FunctionDispatcher construction, user input?
-        self.function_dispatcher: FunctionDispatcher = None
+        if function_dispatcher_modules is None:
+            # TODO: Default FunctionDispatcher construction?
+            raise ValueError("FunctionDispatcher configuration must be provided")
+        self.function_dispatcher: FunctionDispatcher = FunctionDispatcher(function_dispatcher_modules, self)
 
     def start(self) -> None:
         # If no function dispatcher, create one
@@ -179,13 +187,16 @@ class Hallo:
             logger.error(error.get_log_line())
             with open(cls.CONFIG_DEFAULT_FILE, "r") as f:
                 json_obj = json.load(f)
+        # Parse function dispatcher config
+        function_dispatcher_modules = set()
+        for module in json_obj["function_dispatcher"]["modules"]:
+            function_dispatcher_modules.add(module["name"])
         # Create new hallo object
-        new_hallo = cls()
-        new_hallo.default_nick = json_obj["default_nick"]
-        new_hallo.default_prefix = json_obj["default_prefix"]
-        new_hallo.default_full_name = json_obj["default_full_name"]
-        new_hallo.function_dispatcher = FunctionDispatcher.from_json(
-            json_obj["function_dispatcher"], new_hallo
+        new_hallo = cls(
+            default_nick=json_obj["default_nick"],
+            default_prefix=json_obj["default_prefix"],
+            default_full_name=json_obj["default_full_name"],
+            function_dispatcher_modules=function_dispatcher_modules,
         )
         # User groups must be done before servers, as users will try and look up and add user groups!
         for user_group in json_obj["user_groups"]:
@@ -208,7 +219,7 @@ class Hallo:
         """
         self.user_group_list.add(user_group)
 
-    def get_user_group_by_name(self, user_group_name: str) -> Optional[UserGroup]:
+    def get_user_group_by_name(self, user_group_name: str) -> UserGroup | None:
         """
         Returns the UserGroup with the specified name
         :param user_group_name: Name of user group to search for
@@ -235,7 +246,7 @@ class Hallo:
         """
         self.server_list.add(server)
 
-    def get_server_by_name(self, server_name: str) -> Optional[Server]:
+    def get_server_by_name(self, server_name: str) -> Server | None:
         """
         Returns a server matching the given name
         :param server_name: name of the server to search for
@@ -304,7 +315,7 @@ class Hallo:
         """
         self.api_key_list[name] = key
 
-    def get_api_key(self, name: str) -> Optional[str]:
+    def get_api_key(self, name: str) -> str | None:
         """
         Returns a specified api key.
         :param name: Name of the API key to retrieve

--- a/hallo/hallo.py
+++ b/hallo/hallo.py
@@ -50,6 +50,7 @@ class Hallo:
             default_prefix: bool | str = False,
             default_full_name: str = "HalloBot HalloHost HalloServer :an irc bot by spangle",
             function_dispatcher_modules: set | None = None,
+            permission_mask: PermissionMask | None = None,
     ) -> None:
         self.default_nick: str = default_nick
         self.default_prefix: bool | str = default_prefix
@@ -59,7 +60,7 @@ class Hallo:
         self.server_list: set[Server] = set()
         self.api_key_list: dict[str, str] = {}
         self.server_factory: ServerFactory = ServerFactory(self)
-        self.permission_mask: PermissionMask = PermissionMask()
+        self.permission_mask: PermissionMask = permission_mask or PermissionMask()
         self.prom_port = 7265
         server_count.set_function(lambda: len(self.server_list))
         server_connected_count.set_function(lambda: len([s for s in self.server_list.copy() if s.is_connected()]))
@@ -191,12 +192,19 @@ class Hallo:
         function_dispatcher_modules = set()
         for module in json_obj["function_dispatcher"]["modules"]:
             function_dispatcher_modules.add(module["name"])
+        # Parse permission mask config
+        permission_mask = PermissionMask()
+        if "permission_mask" in json_obj:
+            permission_mask = PermissionMask.from_json(
+                json_obj["permission_mask"]
+            )
         # Create new hallo object
         new_hallo = cls(
             default_nick=json_obj["default_nick"],
             default_prefix=json_obj["default_prefix"],
             default_full_name=json_obj["default_full_name"],
             function_dispatcher_modules=function_dispatcher_modules,
+            permission_mask=permission_mask,
         )
         # User groups must be done before servers, as users will try and look up and add user groups!
         for user_group in json_obj["user_groups"]:
@@ -204,10 +212,6 @@ class Hallo:
         for server in json_obj["servers"]:
             new_server = new_hallo.server_factory.new_server_from_json(server)
             new_hallo.add_server(new_server)
-        if "permission_mask" in json_obj:
-            new_hallo.permission_mask = PermissionMask.from_json(
-                json_obj["permission_mask"]
-            )
         for api_key in json_obj["api_keys"]:
             new_hallo.add_api_key(api_key, json_obj["api_keys"][api_key])
         return new_hallo

--- a/hallo/inc/commons.py
+++ b/hallo/inc/commons.py
@@ -5,7 +5,7 @@ import re
 import json
 import random
 from datetime import timedelta
-from typing import TypeVar, Union, Callable, Generic, Type
+from typing import TypeVar, Callable, Generic, Type
 
 import requests
 from prometheus_client import Gauge
@@ -382,7 +382,7 @@ class Commons(object):
         return param_value
 
     @staticmethod
-    def find_any_parameter(param_list: list[str], line: str) -> Union[str, bool]:
+    def find_any_parameter(param_list: list[str], line: str) -> str | bool:
         """
         Finds one of any parameter in a line.
         """

--- a/hallo/inc/commons.py
+++ b/hallo/inc/commons.py
@@ -5,7 +5,7 @@ import re
 import json
 import random
 from datetime import timedelta
-from typing import Optional, TypeVar, Union, Callable, Generic, Type
+from typing import TypeVar, Union, Callable, Generic, Type
 
 import requests
 from prometheus_client import Gauge
@@ -78,7 +78,7 @@ class Commons(object):
         return url[: -len(url_tld) - 1].split(".")[-1]
 
     @staticmethod
-    def string_to_bool(string: str) -> Optional[bool]:
+    def string_to_bool(string: str) -> bool | None:
         """
         Converts a string to a boolean.
         :param string: String to convert to boolean
@@ -262,7 +262,7 @@ class Commons(object):
             return False
 
     @staticmethod
-    def get_digits_from_start_or_end(string: str) -> Optional[str]:
+    def get_digits_from_start_or_end(string: str) -> str | None:
         """
         Gets the longest string of digits from the start or end of a string, or None
         :param string: String to find sequence of digits from
@@ -284,7 +284,7 @@ class Commons(object):
         return None
 
     @staticmethod
-    def get_calc_from_start_or_end(string: str) -> Optional[str]:
+    def get_calc_from_start_or_end(string: str) -> str | None:
         """
         Gets the longest calculation of digits from the start or end of a string, or None
         :param string: String to find calculation from
@@ -306,7 +306,7 @@ class Commons(object):
         return None
 
     @staticmethod
-    def list_greater(list_one: list[float], list_two: list[float]) -> Optional[bool]:
+    def list_greater(list_one: list[float], list_two: list[float]) -> bool | None:
         """
         Checks whether listOne is "greater" than listTwo.
         Checks if an earlier element of listOne is greater than the equally placed element in listTwo
@@ -368,7 +368,7 @@ class Commons(object):
         return data
 
     @staticmethod
-    def find_parameter(param_name: str, line: str) -> Optional[str]:
+    def find_parameter(param_name: str, line: str) -> str | None:
         """
         Finds a parameter value in a line, if the format parameter=value exists in the line
         """
@@ -401,7 +401,7 @@ class Commons(object):
 
 
 class CachedObject(Generic[S]):
-    def __init__(self, setter: Callable[[], S], cache_expiry: Optional[timedelta] = None) -> None:
+    def __init__(self, setter: Callable[[], S], cache_expiry: timedelta | None = None) -> None:
         """
         :type setter: Callable
         :type cache_expiry: timedelta
@@ -410,8 +410,8 @@ class CachedObject(Generic[S]):
         self.cache_expiry: timedelta = (
             cache_expiry if cache_expiry is not None else timedelta(minutes=5)
         )
-        self.cache_time: Optional[datetime.datetime] = None
-        self.value: Optional[S] = None
+        self.cache_time: datetime.datetime | None = None
+        self.value: S | None = None
 
     def get(self) -> S:
         if (

--- a/hallo/inc/commons.py
+++ b/hallo/inc/commons.py
@@ -134,9 +134,7 @@ class Commons(object):
         Returns a string, formatted datetime from a timestamp
         :param time_stamp: unix timestamp
         """
-        return datetime.datetime.utcfromtimestamp(time_stamp).strftime(
-            "%Y-%m-%d %H:%M:%S"
-        )
+        return datetime.datetime.fromtimestamp(time_stamp, tz=datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
     @staticmethod
     def create_headers_dict(headers: list[list[str]]) -> dict[str, str]:

--- a/hallo/inc/commons.py
+++ b/hallo/inc/commons.py
@@ -5,7 +5,7 @@ import re
 import json
 import random
 from datetime import timedelta
-from typing import List, Optional, Dict, TypeVar, Union, Callable, Generic, Type, Set
+from typing import Optional, TypeVar, Union, Callable, Generic, Type
 
 import requests
 from prometheus_client import Gauge
@@ -27,7 +27,7 @@ subscription_menu_count = Gauge(
 )
 
 
-def all_subclasses(cls: Type) -> Set[Type]:
+def all_subclasses(cls: Type) -> set[Type]:
     return set(cls.__subclasses__()).union(
         [s for c in cls.__subclasses__() for s in all_subclasses(c)]
     )
@@ -39,7 +39,7 @@ class Commons(object):
     """
 
     @staticmethod
-    def chunk_string_dot(string: str, length: int) -> List[str]:
+    def chunk_string_dot(string: str, length: int) -> list[str]:
         if len(string) <= length:
             return [string]
         else:
@@ -52,7 +52,7 @@ class Commons(object):
             return list_of_strings
 
     @staticmethod
-    def read_file_to_list(filename: str) -> List[str]:
+    def read_file_to_list(filename: str) -> list[str]:
         with open(filename, "r") as f:
             file_list = []
             raw_line = f.readline()
@@ -139,7 +139,7 @@ class Commons(object):
         )
 
     @staticmethod
-    def create_headers_dict(headers: List[List[str]]) -> Dict[str, str]:
+    def create_headers_dict(headers: list[list[str]]) -> dict[str, str]:
         """
         Creates a headers dictionary, for requests, and adds user agent
         :param headers: List of HTTP headers to add to request
@@ -152,9 +152,9 @@ class Commons(object):
         return headers_dict
 
     @staticmethod
-    def load_url_string(url: str, headers: List[List[str]] = None) -> str:
+    def load_url_string(url: str, headers: list[list[str]] = None) -> str:
         """
-        Takes a url to an xml resource, pulls it and returns a dictionary.
+        Takes a url, pulls it and returns the body of the page.
         :param url: URL to download
         :param headers: List of HTTP headers to add to request
         """
@@ -163,7 +163,7 @@ class Commons(object):
         return resp.text
 
     @staticmethod
-    def load_url_json(url: str, headers: List[List[str]] = None, json_fix: bool = False) -> Dict:
+    def load_url_json(url: str, headers: list[list[str]] = None, json_fix: bool = False) -> dict:
         """
         Takes a url to a json resource, pulls it and returns a dictionary.
         :param url: URL of json to download
@@ -184,7 +184,7 @@ class Commons(object):
         return output_dict
 
     @staticmethod
-    def put_json_to_url(url: str, data: Dict, headers: List[List[str]] = None) -> None:
+    def put_json_to_url(url: str, data: dict, headers: list[list[str]] = None) -> None:
         """
         Converts data to JSON and PUT it to the specified URL
         :param url: URL to send PUT request to
@@ -308,7 +308,7 @@ class Commons(object):
         return None
 
     @staticmethod
-    def list_greater(list_one: List[float], list_two: List[float]) -> Optional[bool]:
+    def list_greater(list_one: list[float], list_two: list[float]) -> Optional[bool]:
         """
         Checks whether listOne is "greater" than listTwo.
         Checks if an earlier element of listOne is greater than the equally placed element in listTwo
@@ -326,7 +326,7 @@ class Commons(object):
         return None
 
     @staticmethod
-    def get_random_int(min_int: int, max_int: int, count: int = 1) -> List[int]:
+    def get_random_int(min_int: int, max_int: int, count: int = 1) -> list[int]:
         """
         Returns a list of random integers in a given range
         :param min_int: Minimum integer to return
@@ -342,7 +342,7 @@ class Commons(object):
         return output_list
 
     @staticmethod
-    def get_random_choice(choice_list: List[T], count: int = 1) -> List[T]:
+    def get_random_choice(choice_list: list[T], count: int = 1) -> list[T]:
         """
         Replacement for random.choice
         :param choice_list: List of choices to choose from
@@ -384,7 +384,7 @@ class Commons(object):
         return param_value
 
     @staticmethod
-    def find_any_parameter(param_list: List[str], line: str) -> Union[str, bool]:
+    def find_any_parameter(param_list: list[str], line: str) -> Union[str, bool]:
         """
         Finds one of any parameter in a line.
         """

--- a/hallo/inc/logger.py
+++ b/hallo/inc/logger.py
@@ -4,7 +4,7 @@ import os
 import sys
 from logging import FileHandler
 from logging.handlers import TimedRotatingFileHandler
-from typing import Dict, Optional
+from typing import Optional
 
 from hallo.destination import Destination
 from hallo.server import Server
@@ -40,7 +40,7 @@ class ChatLogHandler(logging.Handler):
     def __init__(self, root_dir: str):
         super().__init__()
         self.root_dir = root_dir
-        self._handlers: Dict[str, Dict[str, logging.Handler]] = {}
+        self._handlers: dict[str, dict[str, logging.Handler]] = {}
 
     # noinspection PyUnresolvedReferences
     def _get_handler(self, record: logging.LogRecord) -> Optional[logging.Handler]:

--- a/hallo/inc/logger.py
+++ b/hallo/inc/logger.py
@@ -4,7 +4,6 @@ import os
 import sys
 from logging import FileHandler
 from logging.handlers import TimedRotatingFileHandler
-from typing import Optional
 
 from hallo.destination import Destination
 from hallo.server import Server
@@ -43,7 +42,7 @@ class ChatLogHandler(logging.Handler):
         self._handlers: dict[str, dict[str, logging.Handler]] = {}
 
     # noinspection PyUnresolvedReferences
-    def _get_handler(self, record: logging.LogRecord) -> Optional[logging.Handler]:
+    def _get_handler(self, record: logging.LogRecord) -> logging.Handler | None:
         if not hasattr(record, "server") or not isinstance(record.server, Server):
             return None
         server_name = record.server.name

--- a/hallo/inc/menus.py
+++ b/hallo/inc/menus.py
@@ -3,7 +3,7 @@ import os
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from pathlib import Path
-from typing import TypeVar, Generic, Optional, Type, TYPE_CHECKING
+from typing import TypeVar, Generic, Type, TYPE_CHECKING
 
 from hallo.events import message_from_json
 
@@ -60,16 +60,16 @@ class MenuCache(Generic[T]):
         self.menus[menu.msg.server_name][menu.msg.destination_addr].append(menu)
         self.save_to_json()
 
-    def get_menu_by_menu(self, menu: T) -> Optional[T]:
+    def get_menu_by_menu(self, menu: T) -> T | None:
         return self.get_menu_by_id(menu.msg.server_name, menu.msg.destination_addr, menu.msg.message_id)
 
-    def get_menu_by_event(self, msg: 'EventMessage') -> Optional[T]:
+    def get_menu_by_event(self, msg: 'EventMessage') -> T | None:
         return self.get_menu_by_id(msg.server_name, msg.destination_addr, msg.message_id)
 
-    def get_menu_by_callback_event(self, event: 'EventMenuCallback') -> Optional[T]:
+    def get_menu_by_callback_event(self, event: 'EventMenuCallback') -> T | None:
         return self.get_menu_by_id(event.server.name, event.destination.address, event.message_id)
 
-    def get_menu_by_id(self, server_name: str, destination_addr: str, message_id: int) -> Optional[T]:
+    def get_menu_by_id(self, server_name: str, destination_addr: str, message_id: int) -> T | None:
         if message_id is None:
             return None
         dest_menus = self.menus.get(server_name, {}).get(destination_addr, [])

--- a/hallo/inc/menus.py
+++ b/hallo/inc/menus.py
@@ -3,7 +3,7 @@ import os
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from pathlib import Path
-from typing import TypeVar, Generic, Dict, List, Optional, Type, TYPE_CHECKING
+from typing import TypeVar, Generic, Optional, Type, TYPE_CHECKING
 
 from hallo.events import message_from_json
 
@@ -24,11 +24,11 @@ class MenuParseException(MenuException):
 
 class MenuFactory(Generic[T]):
 
-    def __init__(self, classes: List[Type[T]], hallo_obj: 'Hallo'):
+    def __init__(self, classes: list[Type[T]], hallo_obj: 'Hallo'):
         self.menu_classes = classes
         self.hallo = hallo_obj
 
-    def load_menu_from_json(self, data: Dict) -> T:
+    def load_menu_from_json(self, data: dict) -> T:
         menu_class = next(filter(lambda m: m.type == data["menu_type"], self.menu_classes), None)
         if menu_class is None:
             raise MenuParseException(f"Unrecognised menu type: {data['menu_type']}")
@@ -129,14 +129,14 @@ class Menu(ABC):
         raise NotImplementedError
 
     @classmethod
-    def from_json(cls, hallo_obj: 'Hallo', msg: 'EventMessage', data: Dict) -> 'Menu':
+    def from_json(cls, hallo_obj: 'Hallo', msg: 'EventMessage', data: dict) -> 'Menu':
         raise NotImplementedError
 
     @abstractmethod
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         raise NotImplementedError
 
-    def to_full_json(self) -> Dict:
+    def to_full_json(self) -> dict:
         return {
             "menu_type": self.type,
             "menu_msg": self.msg.to_json(),

--- a/hallo/modules/dailys/dailys_field.py
+++ b/hallo/modules/dailys/dailys_field.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABCMeta
 from datetime import date
-from typing import Optional, Dict, Callable
+from typing import Callable
 
 from hallo.events import (
     EventMessage,
@@ -60,13 +60,13 @@ class DailysField(metaclass=ABCMeta):
         """
         self.spreadsheet.save_field(self, data, data_date=data_date)
 
-    def load_data(self, data_date: date) -> Optional[Dict]:
+    def load_data(self, data_date: date) -> dict | None:
         return self.spreadsheet.read_field(self, data_date)
 
     def message_channel(
             self,
             text: str,
-            after_sent_callback: Optional[Callable[[EventMessage], None]] = None
+            after_sent_callback: Callable[[EventMessage], None] | None = None
     ) -> EventMessage:
         evt = EventMessage(
             self.spreadsheet.destination.server,

--- a/hallo/modules/dailys/dailys_repo.py
+++ b/hallo/modules/dailys/dailys_repo.py
@@ -1,12 +1,11 @@
 import json
-from typing import List
 
 import hallo.modules.dailys.dailys_spreadsheet
 
 
 class DailysRepo:
     def __init__(self):
-        self.spreadsheets: List[hallo.modules.dailys.dailys_spreadsheet.DailysSpreadsheet] = []
+        self.spreadsheets: list[hallo.modules.dailys.dailys_spreadsheet.DailysSpreadsheet] = []
 
     def add_spreadsheet(self, spreadsheet: hallo.modules.dailys.dailys_spreadsheet.DailysSpreadsheet):
         self.spreadsheets.append(spreadsheet)

--- a/hallo/modules/dailys/field_mood_models.py
+++ b/hallo/modules/dailys/field_mood_models.py
@@ -1,7 +1,6 @@
 import functools
 from abc import ABC, abstractmethod
 from datetime import time, datetime, date, timedelta
-from typing import Union, Optional
 
 
 @functools.total_ordering
@@ -12,7 +11,7 @@ class MoodTime:
     WAKE = "WakeUpTime"
     SLEEP = "SleepTime"
 
-    def __init__(self, mood_time: Union[str, time]):
+    def __init__(self, mood_time: str | time):
         self.mood_time = mood_time
         if mood_time not in [self.WAKE, self.SLEEP] and not isinstance(mood_time, time):
             raise TypeError("Invalid type for MoodTime")
@@ -68,7 +67,7 @@ class MoodDay:
         return result
 
     @classmethod
-    def from_dict(cls, data: Optional[dict], mood_date: date) -> 'MoodDay':
+    def from_dict(cls, data: dict | None, mood_date: date) -> 'MoodDay':
         if data is None:
             return MoodDay(mood_date, {})
         mood_entries = {}
@@ -121,7 +120,7 @@ class MoodDay:
             key=lambda x: x.mood_time
         )
 
-    def add_request(self, mood_time: MoodTime, message_id: Optional[int]) -> None:
+    def add_request(self, mood_time: MoodTime, message_id: int | None) -> None:
         if message_id is None:
             return None
         request = MoodRequest(mood_time, message_id)
@@ -141,7 +140,7 @@ class MoodEntry(ABC):
     without mood data yet (as it could be a confirmation that a mood request was sent).
     This is the raw data parsed from Dailys data, basically.
     """
-    def __init__(self, mood_time: MoodTime, *, message_id: Optional[int] = None):
+    def __init__(self, mood_time: MoodTime, *, message_id: int | None = None):
         self.mood_time = mood_time
         self.message_id = message_id
 
@@ -184,7 +183,7 @@ class MoodMeasurement(MoodEntry):
     """
     MoodMeasurement is a MoodEntry where the mood measurement data has been supplied by the user
     """
-    def __init__(self, mood_time: MoodTime, mood_dict: dict[str, int], message_id: Optional[int] = None):
+    def __init__(self, mood_time: MoodTime, mood_dict: dict[str, int], message_id: int | None = None):
         super().__init__(mood_time, message_id=message_id)
         self.mood_dict = mood_dict
 
@@ -209,7 +208,7 @@ class MoodTriggeredCache:
     MoodTriggeredCache is a cache of dates to which mood measurements have triggered for that day
     """
     def __init__(self):
-        self.cache: dict[date, list[Union[time, str]]] = {}
+        self.cache: dict[date, list[time | str]] = {}
         # Cache of time values which have triggered already on set days.
 
     def has_triggered(self, mood_date: date, time_val: MoodTime):
@@ -246,14 +245,14 @@ class MoodTimeList:
     def has_non_sleep(self):
         return self.times != [MoodTime(MoodTime.SLEEP)]
 
-    def most_recent_time(self, current_time: time) -> Optional[MoodTime]:
+    def most_recent_time(self, current_time: time) -> MoodTime | None:
         times = [t for t in self.times if t.is_time]
         past_times = [t for t in times if t.mood_time < current_time]
         if len(past_times) == 0:
             return None
         return max(past_times, key=lambda t: t.mood_time)
 
-    def contains_time(self, mood_time: Union[MoodTime, str, time]) -> bool:
+    def contains_time(self, mood_time: MoodTime | str | time) -> bool:
         if isinstance(mood_time, MoodTime):
             return mood_time in self.times
         return MoodTime(mood_time) in self.times

--- a/hallo/modules/dailys/field_question.py
+++ b/hallo/modules/dailys/field_question.py
@@ -1,12 +1,12 @@
 import datetime
 from threading import RLock
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import dateutil.parser
 import isodate
 
 import hallo.modules.dailys.dailys_field
-from hallo.events import EventMessage, EventMinute, Event, RawDataTelegramOutbound, RawDataTelegram
+from hallo.events import EventMessage, EventMinute, Event, RawDataTelegram
 
 if TYPE_CHECKING:
     import hallo.modules.dailys.dailys_spreadsheet
@@ -38,7 +38,7 @@ class RepeatingInterval:
             return True
         return count <= self.count
 
-    def last_time(self) -> Optional[datetime.datetime]:
+    def last_time(self) -> datetime.datetime | None:
         now = datetime.datetime.now(datetime.timezone.utc)
         if now < self.start:
             return None
@@ -49,7 +49,7 @@ class RepeatingInterval:
             count += 1
         return check
 
-    def next_time(self) -> Optional[datetime.datetime]:
+    def next_time(self) -> datetime.datetime | None:
         now = datetime.datetime.now(datetime.timezone.utc)
         if now < self.start:
             return self.start
@@ -72,11 +72,11 @@ class Question:
             time_pattern: RepeatingInterval,
             *,
             allow_custom_answers: bool = True,
-            answer_options: Optional[list[AnswerOption]] = None,
-            creation: Optional[datetime.datetime] = None,
-            deprecation: Optional[datetime.datetime] = None,
+            answer_options: list[AnswerOption] | None = None,
+            creation: datetime.datetime | None = None,
+            deprecation: datetime.datetime | None = None,
             must_answer: bool = False,
-            remind_period: Optional[datetime.timedelta] = None,
+            remind_period: datetime.timedelta | None = None,
     ):
         self.id = qid
         self.question = question
@@ -94,13 +94,13 @@ class Question:
             return True
         return now < self.deprecation
     
-    def last_time(self) -> Optional[datetime.datetime]:
+    def last_time(self) -> datetime.datetime | None:
         last_time = self.time_pattern.last_time()
         if last_time is not None and last_time < self.creation:
             return None
         return last_time
     
-    def next_time(self) -> Optional[datetime.datetime]:
+    def next_time(self) -> datetime.datetime | None:
         next_time = self.time_pattern.next_time()
         if next_time is not None and next_time > self.deprecation:
             return None
@@ -110,9 +110,9 @@ class Question:
             self,
             asked_time: datetime.datetime,
             *,
-            answer: Optional[str] = None,
-            answer_time: Optional[datetime.datetime] = None,
-            question_msg_id: Optional[int] = None
+            answer: str | None = None,
+            answer_time: datetime.datetime | None = None,
+            question_msg_id: int | None = None
     ) -> 'Answer':
         if answer_time is None:
             answer_time = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -180,10 +180,10 @@ class Answer:
             question_id: str,
             asked_time: datetime.datetime,
             *,
-            answer: Optional[str] = None,
-            answer_time: Optional[datetime.datetime] = None,
-            edit_history: Optional[list[AnswerEdit]] = None,
-            question_msg_id: Optional[int] = None,
+            answer: str | None = None,
+            answer_time: datetime.datetime | None = None,
+            edit_history: list[AnswerEdit] | None = None,
+            question_msg_id: int | None = None,
     ):
         self.answer = answer
         self.answer_time = answer_time
@@ -248,7 +248,7 @@ class AnswersData:
             self,
             question: Question,
             answer_datetime: datetime.datetime
-    ) -> Optional[Answer]:
+    ) -> Answer | None:
         date_answers = self.get_answers_for_date(answer_datetime.date())
         for answer in date_answers:
             if answer.for_question(question) and answer.asked_time == answer_datetime:
@@ -293,7 +293,7 @@ class AnswerCache:
                 self._cache[answer_date][answer.question_id] = {}
             self._cache[answer_date][answer.question_id][answer.asked_time] = answer
 
-    def answer_for_question_at_time(self, question: Question, answer_time: datetime.datetime) -> Optional[Answer]:
+    def answer_for_question_at_time(self, question: Question, answer_time: datetime.datetime) -> Answer | None:
         if answer_time.date() not in self._cache:
             self._populate_answers_for_date(answer_time.date())
         return self._cache.get(answer_time.date(), {}).get(question.id, {}).get(answer_time)
@@ -304,7 +304,7 @@ class AnswerCache:
             questions: list[Question],
             *,
             assume_incremental_id: bool = True
-    ) -> Optional[Answer]:
+    ) -> Answer | None:
         if not questions:
             return None
         oldest_date = min([q.time_pattern.start.date() for q in questions])
@@ -390,7 +390,7 @@ class QuestionsField(hallo.modules.dailys.dailys_field.DailysField):
     def passive_events():
         return [EventMessage, EventMinute]
 
-    def passive_trigger(self, evt: Event) -> Optional[Event]:
+    def passive_trigger(self, evt: Event) -> Event | None:
         if isinstance(evt, EventMinute):
             return self._time_trigger()
         if isinstance(evt, EventMessage):
@@ -431,7 +431,7 @@ class QuestionsField(hallo.modules.dailys.dailys_field.DailysField):
         # Save answer
         self.data.save_answer(answer)
 
-    def _msg_trigger(self, evt: EventMessage) -> Optional[EventMessage]:
+    def _msg_trigger(self, evt: EventMessage) -> EventMessage | None:
         # Check if it's asking about open questions
         if evt.text.strip().lower() in ["questions", "open questions", "unanswered question"]:
             return self._handle_questions_list_request(evt)
@@ -450,7 +450,7 @@ class QuestionsField(hallo.modules.dailys.dailys_field.DailysField):
         if text_split[0].lower() == "answer" and text_split[1] in question_dict:
             return self._handle_answer_manual(evt, question_dict[text_split[1]], text_split[2])
 
-    def _handle_answer_reply(self, evt: EventMessage, reply_id: int, answer: str) -> Optional[EventMessage]:
+    def _handle_answer_reply(self, evt: EventMessage, reply_id: int, answer: str) -> EventMessage | None:
         cache = AnswerCache(self.data)
         reply_answer = cache.answer_for_question_msg_id(reply_id, self.questions)
         if reply_answer is None:
@@ -461,7 +461,7 @@ class QuestionsField(hallo.modules.dailys.dailys_field.DailysField):
             f"Answer saved for question ID \"{reply_answer.question_id}\", at {reply_answer.asked_time.isoformat()}"
         ))
 
-    def _handle_answer_manual(self, evt: EventMessage, question: Question, answer: str) -> Optional[EventMessage]:
+    def _handle_answer_manual(self, evt: EventMessage, question: Question, answer: str) -> EventMessage | None:
         latest_time = question.last_time()
         current_answer = self.data.get_answer_for_question_at_time(question, latest_time)
         if current_answer is None:

--- a/hallo/modules/dailys/field_question.py
+++ b/hallo/modules/dailys/field_question.py
@@ -1,6 +1,6 @@
 import datetime
 from threading import RLock
-from typing import Optional, Dict, List, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 import dateutil.parser
 import isodate
@@ -18,7 +18,7 @@ class AnswerOption:
         self.answer = answer
 
     @classmethod
-    def from_dict(cls, json_dict: Dict) -> 'AnswerOption':
+    def from_dict(cls, json_dict: dict) -> 'AnswerOption':
         return AnswerOption(
             json_dict["answer"]
         )
@@ -72,7 +72,7 @@ class Question:
             time_pattern: RepeatingInterval,
             *,
             allow_custom_answers: bool = True,
-            answer_options: Optional[List[AnswerOption]] = None,
+            answer_options: Optional[list[AnswerOption]] = None,
             creation: Optional[datetime.datetime] = None,
             deprecation: Optional[datetime.datetime] = None,
             must_answer: bool = False,
@@ -125,7 +125,7 @@ class Question:
         )
 
     @classmethod
-    def from_dict(cls, json_dict: Dict) -> 'Question':
+    def from_dict(cls, json_dict: dict) -> 'Question':
         creation = None
         if "creation" in json_dict:
             creation = dateutil.parser.parse(json_dict["creation"])
@@ -160,14 +160,14 @@ class AnswerEdit:
         self.answer = answer
         self.answer_time = answer_time
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         return {
             "answer": self.answer,
             "answer_time": self.answer_time.isoformat()
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, str]) -> 'AnswerEdit':
+    def from_dict(cls, data: dict[str, str]) -> 'AnswerEdit':
         return cls(
             data["answer"],
             dateutil.parser.parse(data["answer_time"])
@@ -182,7 +182,7 @@ class Answer:
             *,
             answer: Optional[str] = None,
             answer_time: Optional[datetime.datetime] = None,
-            edit_history: Optional[List[AnswerEdit]] = None,
+            edit_history: Optional[list[AnswerEdit]] = None,
             question_msg_id: Optional[int] = None,
     ):
         self.answer = answer
@@ -210,7 +210,7 @@ class Answer:
         self.answer_time = datetime.datetime.now(datetime.timezone.utc)
 
     @classmethod
-    def from_dict(cls, json_dict: Dict) -> 'Answer':
+    def from_dict(cls, json_dict: dict) -> 'Answer':
         answer_time = None
         if "answer_time" in json_dict:
             answer_time = dateutil.parser.parse(json_dict["answer_time"])
@@ -223,7 +223,7 @@ class Answer:
             question_msg_id=json_dict.get("q_message_id")
         )
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         d = {
             "question_id": self.question_id,
             "asked_time": self.asked_time.isoformat()
@@ -255,14 +255,14 @@ class AnswersData:
                 return answer
         return None
 
-    def get_answers_for_date(self, answer_date: datetime.date) -> List[Answer]:
+    def get_answers_for_date(self, answer_date: datetime.date) -> list[Answer]:
         date_data = self.spreadsheet.read_path("stats/questions/"+answer_date.isoformat()+"/")
         if not date_data:
             return []
         answer_data = date_data[0]["data"]["answers"]
         return [Answer.from_dict(d) for d in answer_data]
 
-    def save_answers_for_date(self, answer_date: datetime.date, answers: List[Answer]):
+    def save_answers_for_date(self, answer_date: datetime.date, answers: list[Answer]):
         with self.lock:
             date_data = {"answers": [a.to_dict() for a in answers]}
             self.spreadsheet.save_field(QuestionsField, date_data, answer_date)
@@ -301,7 +301,7 @@ class AnswerCache:
     def answer_for_question_msg_id(
             self,
             question_msg_id: int,
-            questions: List[Question],
+            questions: list[Question],
             *,
             assume_incremental_id: bool = True
     ) -> Optional[Answer]:
@@ -332,7 +332,7 @@ class AnswerCache:
         # Ran out of dates, return None
         return None
 
-    def latest_answers(self, questions: List[Question]) -> List[Answer]:
+    def latest_answers(self, questions: list[Question]) -> list[Answer]:
         if not questions:
             return []
         unanswered_ids = [q.id for q in questions]
@@ -350,7 +350,7 @@ class AnswerCache:
         # Ran out of dates, return None
         return latest_answers
 
-    def list_unanswered_questions(self, questions: List[Question]) -> List[Question]:
+    def list_unanswered_questions(self, questions: list[Question]) -> list[Question]:
         questions_dict = {q.id: q for q in questions}
         unanswered = []
         for answer in self.latest_answers(questions):
@@ -365,7 +365,7 @@ class QuestionsField(hallo.modules.dailys.dailys_field.DailysField):
     def __init__(
             self,
             spreadsheet: 'hallo.modules.dailys.dailys_spreadsheet.DailysSpreadsheet',
-            questions: List[Question]
+            questions: list[Question]
     ):
         super().__init__(spreadsheet)
         self.questions = questions

--- a/hallo/modules/subscriptions/common_e6_key.py
+++ b/hallo/modules/subscriptions/common_e6_key.py
@@ -1,5 +1,5 @@
 from threading import RLock
-from typing import Dict, TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional
 
 from yippi import YippiClient
 
@@ -17,7 +17,7 @@ class E6KeysCommon(hallo.modules.subscriptions.subscription_common.SubscriptionC
 
     def __init__(self, hallo_obj: 'Hallo'):
         super().__init__(hallo_obj)
-        self.list_clients: Dict['User', YippiClient] = dict()
+        self.list_clients: dict['User', YippiClient] = dict()
 
     def get_client_by_user(self, user: 'User', allow_default: bool = True) -> Optional['YippiClient']:
         if user in self.list_clients:
@@ -45,9 +45,9 @@ class E6KeysCommon(hallo.modules.subscriptions.subscription_common.SubscriptionC
     def add_client(self, user: 'User', client: YippiClient) -> None:
         self.list_clients[user] = client
 
-    def to_json(self) -> Optional[Dict]:
+    def to_json(self) -> Optional[dict]:
         return None
 
     @staticmethod
-    def from_json(json_obj: Optional[Dict], hallo_obj: 'Hallo') -> 'E6KeysCommon':
+    def from_json(json_obj: Optional[dict], hallo_obj: 'Hallo') -> 'E6KeysCommon':
         return E6KeysCommon(hallo_obj)

--- a/hallo/modules/subscriptions/common_e6_key.py
+++ b/hallo/modules/subscriptions/common_e6_key.py
@@ -45,9 +45,9 @@ class E6KeysCommon(hallo.modules.subscriptions.subscription_common.SubscriptionC
     def add_client(self, user: 'User', client: YippiClient) -> None:
         self.list_clients[user] = client
 
-    def to_json(self) -> Optional[dict]:
+    def to_json(self) -> dict | None:
         return None
 
     @staticmethod
-    def from_json(json_obj: Optional[dict], hallo_obj: 'Hallo') -> 'E6KeysCommon':
+    def from_json(json_obj: dict | None, hallo_obj: 'Hallo') -> 'E6KeysCommon':
         return E6KeysCommon(hallo_obj)

--- a/hallo/modules/subscriptions/common_fa_key.py
+++ b/hallo/modules/subscriptions/common_fa_key.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from datetime import timedelta, datetime
-from typing import Optional, Union, Callable, TYPE_CHECKING
+from typing import Optional, Callable, TYPE_CHECKING
 
 import dateutil.parser
 
@@ -97,7 +97,7 @@ class FAKey:
                 self.timeout,
             )
 
-        def _get_api_data(self, path: str, needs_cookie: bool = False) -> Union[dict, list]:
+        def _get_api_data(self, path: str, needs_cookie: bool = False) -> dict | list:
             fa_api_url = os.getenv("FA_API_URL", "https://faexport.spangle.org.uk")
             url = "{}/{}".format(fa_api_url, path)
             if needs_cookie:
@@ -134,7 +134,7 @@ class FAKey:
             fav_page = FAKey.FAReader.FAUserFavouritesPage(id_list, username)
             return fav_page
 
-        def get_submission_page(self, submission_id: Union[int, str]) -> 'FAKey.FAReader.FAViewSubmissionPage':
+        def get_submission_page(self, submission_id: int | str) -> 'FAKey.FAReader.FAViewSubmissionPage':
             data = self._get_api_data("/submission/{}.json".format(submission_id))
 
             def comment_data_getter():
@@ -147,7 +147,7 @@ class FAKey:
             )
             return sub_page
 
-        def get_journal_page(self, journal_id: Union[int, str]) -> 'FAKey.FAReader.FAViewJournalPage':
+        def get_journal_page(self, journal_id: int | str) -> 'FAKey.FAReader.FAViewJournalPage':
             data = self._get_api_data("/journal/{}.json".format(journal_id))
 
             def comment_data_getter():

--- a/hallo/modules/subscriptions/common_fa_key.py
+++ b/hallo/modules/subscriptions/common_fa_key.py
@@ -39,11 +39,11 @@ class FAKeysCommon(hallo.modules.subscriptions.subscription_common.SubscriptionC
     def add_key(self, key: 'FAKey') -> None:
         self.list_keys[key.user] = key
 
-    def to_json(self) -> Optional[dict]:
+    def to_json(self) -> dict | None:
         return None
 
     @staticmethod
-    def from_json(json_obj: Optional[dict], hallo_obj: 'Hallo') -> 'FAKeysCommon':
+    def from_json(json_obj: dict | None, hallo_obj: 'Hallo') -> 'FAKeysCommon':
         return FAKeysCommon(hallo_obj)
 
 
@@ -54,7 +54,7 @@ class FAKey:
         self.cookie_b = cookie_b
         if self.cookie_a is None or self.cookie_b is None:
             raise Exception("Cookie A or Cookie B was not set.")
-        self.fa_reader: Optional[FAKey.FAReader] = None
+        self.fa_reader: FAKey.FAReader | None = None
 
     def get_fa_reader(self) -> 'FAKey.FAReader':
         if self.fa_reader is None:
@@ -392,7 +392,7 @@ class FAKey:
             def __init__(self, data: dict, shout_data_getter: Callable[[], dict], username: str):
                 self.username: str = username
                 self.name: str = data["full_name"]
-                self.user_title: Optional[str] = (
+                self.user_title: str | None = (
                     data["user_title"] if len(data["user_title"]) != 0 else None
                 )
                 self.registered_since: datetime = dateutil.parser.parse(data["registered_at"])
@@ -408,7 +408,7 @@ class FAKey:
                 # contact_info
                 # featured_submission
                 self._shout_data_getter: Callable[[], dict] = shout_data_getter
-                self._shout_cache: Optional[list[FAKey.FAReader.FAShout]] = None
+                self._shout_cache: list[FAKey.FAReader.FAShout] | None = None
                 # watcher lists
                 self.watched_by: list[FAKey.FAReader.FAWatch] = []
                 for watch in data["watchers"]["recent"]:
@@ -489,7 +489,7 @@ class FAKey:
                 self.keywords: list[str] = data["keywords"]
                 self.rating: str = data["rating"]
                 self._comments_section_getter: Callable[[], dict] = comments_data_getter
-                self._comments_section_cache: Optional[FAKey.FAReader.FACommentsSection] = None
+                self._comments_section_cache: FAKey.FAReader.FACommentsSection | None = None
 
             @property
             def comments_section(self) -> 'FAKey.FAReader.FACommentsSection':
@@ -546,11 +546,11 @@ class FAKey:
         class FAComment:
             def __init__(
                     self,
-                    username: Optional[str],
-                    name: Optional[str],
-                    avatar_link: Optional[str],
+                    username: str | None,
+                    name: str | None,
+                    avatar_link: str | None,
                     comment_id: str,
-                    posted_datetime: Optional[datetime],
+                    posted_datetime: datetime | None,
                     text: str,
                     is_deleted: bool,
                     parent_comment: Optional['FAKey.FAReader.FAComment'] = None,
@@ -562,7 +562,7 @@ class FAKey:
                 self.posted_datetime: datetime = posted_datetime
                 self.text: str = text
                 self.is_deleted = is_deleted
-                self.parent_comment: Optional[FAKey.FAReader.FAComment] = parent_comment
+                self.parent_comment: FAKey.FAReader.FAComment | None = parent_comment
                 self.reply_comments: list[FAKey.FAReader.FAComment] = []
 
         class FAViewJournalPage:
@@ -570,14 +570,14 @@ class FAKey:
                 self.journal_id: str = journal_id
                 self.username: str = data["profile_name"]
                 self.name: str = data["name"]
-                self.avatar_link: Optional[str] = data["avatar"]
+                self.avatar_link: str | None = data["avatar"]
                 self.title: str = data["title"]
                 self.posted_datetime: datetime = dateutil.parser.parse(data["posted_at"])
-                self.journal_header: Optional[str] = data["journal_header"]
+                self.journal_header: str | None = data["journal_header"]
                 self.journal_text: str = data["journal_body"]
-                self.journal_footer: Optional[str] = data["journal_footer"]
+                self.journal_footer: str | None = data["journal_footer"]
                 self._comments_section_getter: Callable[[], dict] = comments_data_getter
-                self._comments_section_cache: Optional[FAKey.FAReader.FACommentsSection] = None
+                self._comments_section_cache: FAKey.FAReader.FACommentsSection | None = None
 
             @property
             def comments_section(self) -> 'FAKey.FAReader.FACommentsSection':

--- a/hallo/modules/subscriptions/common_fa_key.py
+++ b/hallo/modules/subscriptions/common_fa_key.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from datetime import timedelta, datetime
-from typing import Dict, Optional, Union, List, Callable, TYPE_CHECKING
+from typing import Optional, Union, Callable, TYPE_CHECKING
 
 import dateutil.parser
 
@@ -21,7 +21,7 @@ class FAKeysCommon(hallo.modules.subscriptions.subscription_common.SubscriptionC
 
     def __init__(self, hallo_obj: 'Hallo'):
         super().__init__(hallo_obj)
-        self.list_keys: Dict[User, FAKey] = dict()
+        self.list_keys: dict[User, FAKey] = dict()
 
     def get_key_by_user(self, user: User) -> Optional['FAKey']:
         if user in self.list_keys:
@@ -39,11 +39,11 @@ class FAKeysCommon(hallo.modules.subscriptions.subscription_common.SubscriptionC
     def add_key(self, key: 'FAKey') -> None:
         self.list_keys[key.user] = key
 
-    def to_json(self) -> Optional[Dict]:
+    def to_json(self) -> Optional[dict]:
         return None
 
     @staticmethod
-    def from_json(json_obj: Optional[Dict], hallo_obj: 'Hallo') -> 'FAKeysCommon':
+    def from_json(json_obj: Optional[dict], hallo_obj: 'Hallo') -> 'FAKeysCommon':
         return FAKeysCommon(hallo_obj)
 
 
@@ -97,7 +97,7 @@ class FAKey:
                 self.timeout,
             )
 
-        def _get_api_data(self, path: str, needs_cookie: bool = False) -> Union[Dict, List]:
+        def _get_api_data(self, path: str, needs_cookie: bool = False) -> Union[dict, list]:
             fa_api_url = os.getenv("FA_API_URL", "https://faexport.spangle.org.uk")
             url = "{}/{}".format(fa_api_url, path)
             if needs_cookie:
@@ -130,7 +130,7 @@ class FAKey:
 
         def get_user_fav_page(self, username: str) -> 'FAKey.FAReader.FAUserFavouritesPage':
             # This endpoint returns a list of submission IDs
-            id_list: List[int] = self._get_api_data("/user/{}/favorites.json".format(username))
+            id_list: list[int] = self._get_api_data("/user/{}/favorites.json".format(username))
             fav_page = FAKey.FAReader.FAUserFavouritesPage(id_list, username)
             return fav_page
 
@@ -166,9 +166,9 @@ class FAKey:
             return search_page
 
         class FANotificationsPage:
-            def __init__(self, data: Dict):
+            def __init__(self, data: dict):
                 self.username: str = data["current_user"]["profile_name"]
-                self.watches: List[FAKey.FAReader.FANotificationWatch] = []
+                self.watches: list[FAKey.FAReader.FANotificationWatch] = []
                 watch_list = data["new_watches"]
                 for watch_notif in watch_list:
                     try:
@@ -180,7 +180,7 @@ class FAKey:
                         self.watches.append(new_watch)
                     except Exception as e:
                         logger.error("Failed to read watch: ", exc_info=e)
-                self.submission_comments: List[FAKey.FAReader.FANotificationCommentSubmission] = []
+                self.submission_comments: list[FAKey.FAReader.FANotificationCommentSubmission] = []
                 sub_comment_list = data["new_submission_comments"]
                 for sub_comment_notif in sub_comment_list:
                     try:
@@ -196,7 +196,7 @@ class FAKey:
                         self.submission_comments.append(new_comment)
                     except Exception as e:
                         logger.error("Failed to read submission comment: ", exc_info=e)
-                self.journal_comments: List[FAKey.FAReader.FANotificationCommentJournal] = []
+                self.journal_comments: list[FAKey.FAReader.FANotificationCommentJournal] = []
                 jou_comment_list = data["new_journal_comments"]
                 for jou_comment_notif in jou_comment_list:
                     try:
@@ -212,7 +212,7 @@ class FAKey:
                         self.journal_comments.append(new_comment)
                     except Exception as e:
                         logger.error("Failed to read journal comment: ", exc_info=e)
-                self.shouts: List[FAKey.FAReader.FANotificationShout] = []
+                self.shouts: list[FAKey.FAReader.FANotificationShout] = []
                 shout_list = data["new_shouts"]
                 for shout_notif in shout_list:
                     try:
@@ -225,7 +225,7 @@ class FAKey:
                         self.shouts.append(new_shout)
                     except Exception as e:
                         logger.error("Failed to read shout: ", exc_info=e)
-                self.favourites: List[FAKey.FAReader.FANotificationFavourite] = []
+                self.favourites: list[FAKey.FAReader.FANotificationFavourite] = []
                 fav_list = data["new_favorites"]
                 for fav_notif in fav_list:
                     try:
@@ -239,7 +239,7 @@ class FAKey:
                         self.favourites.append(new_fav)
                     except Exception as e:
                         logger.error("Failed to read favourite: ", exc_info=e)
-                self.journals: List[FAKey.FAReader.FANotificationJournal] = []
+                self.journals: list[FAKey.FAReader.FANotificationJournal] = []
                 jou_list = data["new_journals"]
                 for jou_notif in jou_list:
                     try:
@@ -339,8 +339,8 @@ class FAKey:
                 self.name: str = name
 
         class FASubmissionsPage:
-            def __init__(self, data: Dict):
-                self.submissions: List[FAKey.FAReader.FANotificationSubmission] = []
+            def __init__(self, data: dict):
+                self.submissions: list[FAKey.FAReader.FANotificationSubmission] = []
                 subs_list = data["new_submissions"]
                 for sub_notif in subs_list:
                     new_submission = FAKey.FAReader.FANotificationSubmission(
@@ -364,9 +364,9 @@ class FAKey:
                 self.name: str = name
 
         class FANotesPage:
-            def __init__(self, data: Dict, folder: str):
+            def __init__(self, data: dict, folder: str):
                 self.folder: str = folder
-                self.notes: List[FAKey.FAReader.FANote] = []
+                self.notes: list[FAKey.FAReader.FANote] = []
                 for note in data:
                     new_note = FAKey.FAReader.FANote(
                         note["note_id"],
@@ -389,7 +389,7 @@ class FAKey:
                 self.is_read: bool = is_read
 
         class FAUserPage:
-            def __init__(self, data: Dict, shout_data_getter: Callable[[], Dict], username: str):
+            def __init__(self, data: dict, shout_data_getter: Callable[[], dict], username: str):
                 self.username: str = username
                 self.name: str = data["full_name"]
                 self.user_title: Optional[str] = (
@@ -407,10 +407,10 @@ class FAKey:
                 # artist_info
                 # contact_info
                 # featured_submission
-                self._shout_data_getter: Callable[[], Dict] = shout_data_getter
-                self._shout_cache: Optional[List[FAKey.FAReader.FAShout]] = None
+                self._shout_data_getter: Callable[[], dict] = shout_data_getter
+                self._shout_cache: Optional[list[FAKey.FAReader.FAShout]] = None
                 # watcher lists
-                self.watched_by: List[FAKey.FAReader.FAWatch] = []
+                self.watched_by: list[FAKey.FAReader.FAWatch] = []
                 for watch in data["watchers"]["recent"]:
                     watcher_username = watch["link"].split("/")[-2]
                     watcher_name = watch["name"]
@@ -418,7 +418,7 @@ class FAKey:
                         watcher_username, watcher_name, self.username, self.name
                     )
                     self.watched_by.append(new_watch)
-                self.is_watching: List[FAKey.FAReader.FAWatch] = []
+                self.is_watching: list[FAKey.FAReader.FAWatch] = []
                 for watch in data["watching"]["recent"]:
                     watched_username = watch["link"].split("/")[-2]
                     watched_name = watch["name"]
@@ -428,7 +428,7 @@ class FAKey:
                     self.is_watching.append(new_watch)
 
             @property
-            def shouts(self) -> List['FAKey.FAReader.FAShout']:
+            def shouts(self) -> list['FAKey.FAReader.FAShout']:
                 if self._shout_cache is None:
                     self._shout_cache = []
                     shout_data = self._shout_data_getter()
@@ -462,12 +462,12 @@ class FAKey:
                 self.watched_name: str = watched_name
 
         class FAUserFavouritesPage:
-            def __init__(self, id_list: List[int], username: str):
+            def __init__(self, id_list: list[int], username: str):
                 self.username: str = username
-                self.submission_ids: List[int] = id_list
+                self.submission_ids: list[int] = id_list
 
         class FAViewSubmissionPage:
-            def __init__(self, data: Dict, comments_data_getter: Callable[[], Dict], submission_id: str):
+            def __init__(self, data: dict, comments_data_getter: Callable[[], dict], submission_id: str):
                 self.submission_id: str = submission_id
                 self.title: str = data["title"]
                 self.full_image: str = data["download"]
@@ -486,9 +486,9 @@ class FAKey:
                 self.num_views: int = int(data["views"])
                 # resolution_x = None
                 # resolution_y = None
-                self.keywords: List[str] = data["keywords"]
+                self.keywords: list[str] = data["keywords"]
                 self.rating: str = data["rating"]
-                self._comments_section_getter: Callable[[], Dict] = comments_data_getter
+                self._comments_section_getter: Callable[[], dict] = comments_data_getter
                 self._comments_section_cache: Optional[FAKey.FAReader.FACommentsSection] = None
 
             @property
@@ -501,8 +501,8 @@ class FAKey:
                 return self._comments_section_cache
 
         class FACommentsSection:
-            def __init__(self, comments_data: Dict):
-                self.top_level_comments: List[FAKey.FAReader.FAComment] = []
+            def __init__(self, comments_data: dict):
+                self.top_level_comments: list[FAKey.FAReader.FAComment] = []
                 for comment in comments_data:
                     comment_id = comment["id"]
                     text = comment["text"].strip()
@@ -563,10 +563,10 @@ class FAKey:
                 self.text: str = text
                 self.is_deleted = is_deleted
                 self.parent_comment: Optional[FAKey.FAReader.FAComment] = parent_comment
-                self.reply_comments: List[FAKey.FAReader.FAComment] = []
+                self.reply_comments: list[FAKey.FAReader.FAComment] = []
 
         class FAViewJournalPage:
-            def __init__(self, data: Dict, comments_data_getter: Callable[[], Dict], journal_id: str):
+            def __init__(self, data: dict, comments_data_getter: Callable[[], dict], journal_id: str):
                 self.journal_id: str = journal_id
                 self.username: str = data["profile_name"]
                 self.name: str = data["name"]
@@ -576,7 +576,7 @@ class FAKey:
                 self.journal_header: Optional[str] = data["journal_header"]
                 self.journal_text: str = data["journal_body"]
                 self.journal_footer: Optional[str] = data["journal_footer"]
-                self._comments_section_getter: Callable[[], Dict] = comments_data_getter
+                self._comments_section_getter: Callable[[], dict] = comments_data_getter
                 self._comments_section_cache: Optional[FAKey.FAReader.FACommentsSection] = None
 
             @property
@@ -589,6 +589,6 @@ class FAKey:
                 return self._comments_section_cache
 
         class FASearchPage:
-            def __init__(self, id_list: List[str], search_term: str):
+            def __init__(self, id_list: list[str], search_term: str):
                 self.search_term: str = search_term
-                self.id_list: List[str] = id_list
+                self.id_list: list[str] = id_list

--- a/hallo/modules/subscriptions/source.py
+++ b/hallo/modules/subscriptions/source.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, List, Optional, Dict, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from hallo.destination import Channel, User, Destination
 from hallo.events import EventMessage
@@ -12,7 +12,7 @@ Update = TypeVar("Update")
 
 class Source(ABC, Generic[State, Update]):
     type_name: str = None
-    type_names: List[str] = None
+    type_names: list[str] = None
 
     def __init__(self):
         pass
@@ -50,7 +50,7 @@ class Source(ABC, Generic[State, Update]):
             channel: Optional[Channel],
             user: Optional[User],
             update: Update
-    ) -> List[EventMessage]:
+    ) -> list[EventMessage]:
         """
         Creates a list of events to represent a given update. This should have the oldest update first.
         """
@@ -61,9 +61,9 @@ class Source(ABC, Generic[State, Update]):
 
     @classmethod
     @abstractmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'Source':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'Source':
         pass
 
     @abstractmethod
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         pass

--- a/hallo/modules/subscriptions/source.py
+++ b/hallo/modules/subscriptions/source.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 from hallo.destination import Channel, User, Destination
 from hallo.events import EventMessage
@@ -36,7 +36,7 @@ class Source(ABC, Generic[State, Update]):
         pass
 
     @abstractmethod
-    def state_change(self, state: State) -> Optional[Update]:
+    def state_change(self, state: State) -> Update | None:
         pass
 
     @abstractmethod
@@ -47,8 +47,8 @@ class Source(ABC, Generic[State, Update]):
     def events(
             self,
             server: Server,
-            channel: Optional[Channel],
-            user: Optional[User],
+            channel: Channel | None,
+            user: User | None,
             update: Update
     ) -> list[EventMessage]:
         """

--- a/hallo/modules/subscriptions/source_e621.py
+++ b/hallo/modules/subscriptions/source_e621.py
@@ -1,5 +1,4 @@
 import urllib.parse
-from typing import Dict, List, Optional
 
 from yippi import Post, Rating, YippiClient
 
@@ -19,14 +18,14 @@ def e6_client_from_input(user: User, sub_repo) -> YippiClient:
 
 class E621Source(hallo.modules.subscriptions.stream_source.StreamSource[Post]):
     type_name: str = "e621"
-    type_names: List[str] = ["e621", "e621 search", "search e621"]
+    type_names: list[str] = ["e621", "e621 search", "search e621"]
 
     def __init__(
             self,
             search: str,
             e6_client: YippiClient,
             owner: 'User',
-            last_keys: List[hallo.modules.subscriptions.stream_source.Key] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] = None
     ):
         super().__init__(last_keys)
         self.search: str = search
@@ -49,7 +48,7 @@ class E621Source(hallo.modules.subscriptions.stream_source.StreamSource[Post]):
             user
         )
 
-    def current_state(self) -> List[Post]:
+    def current_state(self) -> list[Post]:
         return self.e6_client.posts(self.search)
 
     def item_to_key(self, item: Post) -> hallo.modules.subscriptions.stream_source.Key:
@@ -58,8 +57,8 @@ class E621Source(hallo.modules.subscriptions.stream_source.StreamSource[Post]):
     def item_to_event(
             self,
             server: Server,
-            channel: Optional[Channel],
-            user: Optional[User],
+            channel: Channel | None,
+            user: User | None,
             item: Post
     ) -> EventMessage:
         link = f"https://e621.net/posts/{item.id}"
@@ -76,7 +75,7 @@ class E621Source(hallo.modules.subscriptions.stream_source.StreamSource[Post]):
         )
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'E621Source':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'E621Source':
         user_addr = json_data["e621_user_address"]
         owner = destination.server.get_user_by_address(user_addr)
         e6_client = e6_client_from_input(owner, sub_repo)
@@ -87,7 +86,7 @@ class E621Source(hallo.modules.subscriptions.stream_source.StreamSource[Post]):
             json_data["last_keys"]
         )
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "last_keys": self.last_keys,

--- a/hallo/modules/subscriptions/source_e621_backlog.py
+++ b/hallo/modules/subscriptions/source_e621_backlog.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from yippi import Post, YippiClient
 
@@ -43,12 +43,12 @@ class E621BacklogTaggingSource(hallo.modules.subscriptions.source_e621_tagging.E
             sub_repo: 'hallo.modules.subscriptions.subscription_repo.SubscriptionRepo',
             owner: User,
             tags: list[str],
-            start_id: Optional[int] = None,
-            current_batch_ids: Optional[list[int]] = None,
-            sent_ids: Optional[list[int]] = None,
+            start_id: int | None = None,
+            current_batch_ids: list[int] | None = None,
+            sent_ids: list[int] | None = None,
             batch_size: int = 5,
-            remaining_count: Optional[int] = None,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            remaining_count: int | None = None,
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(search, e6_client, sub_repo, owner, tags, last_keys)
         self.start_id = start_id

--- a/hallo/modules/subscriptions/source_e621_backlog.py
+++ b/hallo/modules/subscriptions/source_e621_backlog.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from yippi import Post, YippiClient
 
@@ -28,7 +28,7 @@ class E621BacklogTaggingMenu(hallo.modules.subscriptions.source_e621_tagging.E62
 
 class E621BacklogTaggingSource(hallo.modules.subscriptions.source_e621_tagging.E621TaggingSource):
     type_name = "e621_backlog_tagging"
-    type_names: List[str] = [
+    type_names: list[str] = [
         "e621 backlog tagging",
         "e621 backlog tagging search",
         "tagging e621 backlog",
@@ -42,13 +42,13 @@ class E621BacklogTaggingSource(hallo.modules.subscriptions.source_e621_tagging.E
             e6_client: YippiClient,
             sub_repo: 'hallo.modules.subscriptions.subscription_repo.SubscriptionRepo',
             owner: User,
-            tags: List[str],
+            tags: list[str],
             start_id: Optional[int] = None,
-            current_batch_ids: Optional[List[int]] = None,
-            sent_ids: Optional[List[int]] = None,
+            current_batch_ids: Optional[list[int]] = None,
+            sent_ids: Optional[list[int]] = None,
             batch_size: int = 5,
             remaining_count: Optional[int] = None,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(search, e6_client, sub_repo, owner, tags, last_keys)
         self.start_id = start_id
@@ -65,7 +65,7 @@ class E621BacklogTaggingSource(hallo.modules.subscriptions.source_e621_tagging.E
     def item_text_prefix(self) -> str:
         return f'New backlog tagging item on "{self.search}" e621 search.'
 
-    def current_state(self) -> List[Post]:
+    def current_state(self) -> list[Post]:
         if self.start_id is None:
             self.start_id = self.find_start_id()
             self.generate_next_batch()
@@ -162,7 +162,7 @@ class E621BacklogTaggingSource(hallo.modules.subscriptions.source_e621_tagging.E
         return True
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'E621BacklogTaggingSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'E621BacklogTaggingSource':
         user_addr = json_data["e621_user_address"]
         user = destination.server.get_user_by_address(user_addr)
         e6_client = hallo.modules.subscriptions.source_e621.e6_client_from_input(user, sub_repo)
@@ -180,7 +180,7 @@ class E621BacklogTaggingSource(hallo.modules.subscriptions.source_e621_tagging.E
             json_data["last_keys"]
         )
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "last_keys": self.last_keys,

--- a/hallo/modules/subscriptions/source_e621_tagging.py
+++ b/hallo/modules/subscriptions/source_e621_tagging.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from yippi import Post, Rating, YippiClient
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import hallo.modules.subscriptions.subscription_repo
 
 
-def buttons_for_submission(tag_results: Dict[str, bool], page: int = 1) -> List[List[MenuButton]]:
+def buttons_for_submission(tag_results: dict[str, bool], page: int = 1) -> list[list[MenuButton]]:
     columns = 2
     rows = 6
     per_page = columns * rows
@@ -71,7 +71,7 @@ class E621TaggingMenu(Menu):
             e6_client: YippiClient,
             post_id: int,
             search: str,
-            tag_results: Dict[str, bool],
+            tag_results: dict[str, bool],
             page: int = 1
     ) -> None:
         super().__init__(msg)
@@ -158,14 +158,14 @@ class E621TaggingMenu(Menu):
         buttons = buttons_for_submission(self.tag_results, self.page)
         self.update(None, buttons)
 
-    def update(self, text: Optional[str], menu_buttons: Optional[List[List[MenuButton]]]) -> None:
+    def update(self, text: Optional[str], menu_buttons: Optional[list[list[MenuButton]]]) -> None:
         new_event = self.msg.create_edit(text=text, menu_buttons=menu_buttons)
         self.msg.server.edit(self.msg, new_event)
         self.msg = new_event
         self.clicked = False
 
     @classmethod
-    def from_json(cls, hallo_obj: 'Hallo', msg: 'EventMessage', data: Dict) -> 'Menu':
+    def from_json(cls, hallo_obj: 'Hallo', msg: 'EventMessage', data: dict) -> 'Menu':
         server = hallo_obj.get_server_by_name(msg.server_name)
         user = server.get_user_by_address(data["user_addr"])
         if user is None:
@@ -190,7 +190,7 @@ class E621TaggingMenu(Menu):
             data["page"]
         )
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "user_addr": self.user.address,
             "post_id": self.post_id,
@@ -202,7 +202,7 @@ class E621TaggingMenu(Menu):
 
 class E621TaggingSource(hallo.modules.subscriptions.source_e621.E621Source):
     type_name = "e621_tagging"
-    type_names: List[str] = ["e621 tagging", "e621 tagging search", "tagging e621"]
+    type_names: list[str] = ["e621 tagging", "e621 tagging search", "tagging e621"]
 
     def __init__(
             self,
@@ -210,13 +210,13 @@ class E621TaggingSource(hallo.modules.subscriptions.source_e621.E621Source):
             e6_client: YippiClient,
             sub_repo: 'hallo.modules.subscriptions.subscription_repo.SubscriptionRepo',
             owner: User,
-            tags: List[str],
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            tags: list[str],
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(search, e6_client, owner, last_keys)
         self.sub_repo = sub_repo
         self.owner = owner
-        self.tags: List[str] = tags
+        self.tags: list[str] = tags
 
     @classmethod
     def from_input(cls, argument: str, user: User, sub_repo) -> 'E621TaggingSource':
@@ -288,7 +288,7 @@ class E621TaggingSource(hallo.modules.subscriptions.source_e621.E621Source):
         return msg
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'E621TaggingSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'E621TaggingSource':
         user_addr = json_data["e621_user_address"]
         user = destination.server.get_user_by_address(user_addr)
         e6_client = hallo.modules.subscriptions.source_e621.e6_client_from_input(user, sub_repo)
@@ -301,7 +301,7 @@ class E621TaggingSource(hallo.modules.subscriptions.source_e621.E621Source):
             json_data["last_keys"]
         )
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "last_keys": self.last_keys,

--- a/hallo/modules/subscriptions/source_e621_tagging.py
+++ b/hallo/modules/subscriptions/source_e621_tagging.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from yippi import Post, Rating, YippiClient
 
@@ -158,7 +158,7 @@ class E621TaggingMenu(Menu):
         buttons = buttons_for_submission(self.tag_results, self.page)
         self.update(None, buttons)
 
-    def update(self, text: Optional[str], menu_buttons: Optional[list[list[MenuButton]]]) -> None:
+    def update(self, text: str | None, menu_buttons: list[list[MenuButton]] | None) -> None:
         new_event = self.msg.create_edit(text=text, menu_buttons=menu_buttons)
         self.msg.server.edit(self.msg, new_event)
         self.msg = new_event
@@ -211,7 +211,7 @@ class E621TaggingSource(hallo.modules.subscriptions.source_e621.E621Source):
             sub_repo: 'hallo.modules.subscriptions.subscription_repo.SubscriptionRepo',
             owner: User,
             tags: list[str],
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(search, e6_client, owner, last_keys)
         self.sub_repo = sub_repo
@@ -266,8 +266,8 @@ class E621TaggingSource(hallo.modules.subscriptions.source_e621.E621Source):
     def item_to_event(
             self,
             server: Server,
-            channel: Optional[Channel],
-            user: Optional[User],
+            channel: Channel | None,
+            user: User | None,
             item: Post
     ) -> EventMessage:
         # Check tags

--- a/hallo/modules/subscriptions/source_fa_favs.py
+++ b/hallo/modules/subscriptions/source_fa_favs.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List, NewType
+from typing import Optional, NewType
 
 import hallo.modules.subscriptions.subscription_exception
 from hallo.destination import Channel, User, Destination
@@ -41,7 +41,7 @@ def fa_key_from_input(user: User, sub_repo) -> hallo.modules.subscriptions.commo
 
 class FAFavsSource(hallo.modules.subscriptions.stream_source.StreamSource[SubmissionId]):
     type_name: str = "fa_user_favs"
-    type_names: List[str] = [
+    type_names: list[str] = [
         "fa user favs",
         "furaffinity user favs",
         "furaffinity user favourites",
@@ -54,7 +54,7 @@ class FAFavsSource(hallo.modules.subscriptions.stream_source.StreamSource[Submis
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
             username: str,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(last_keys)
         self.username = username
@@ -99,13 +99,13 @@ class FAFavsSource(hallo.modules.subscriptions.stream_source.StreamSource[Submis
         fa_key = fa_key_from_input(user, sub_repo)
         return FAFavsSource(fa_key, argument)
 
-    def current_state(self) -> List[SubmissionId]:
+    def current_state(self) -> list[SubmissionId]:
         fa_reader = self.fa_key.get_fa_reader()
         favs_page = fa_reader.get_user_fav_page(self.username)
         return [SubmissionId(x) for x in favs_page.submission_ids]
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FAFavsSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FAFavsSource':
         user_addr = json_data["fa_key_user_address"]
         fa_key = fa_key_from_json(user_addr, destination.server, sub_repo)
         return FAFavsSource(
@@ -114,7 +114,7 @@ class FAFavsSource(hallo.modules.subscriptions.stream_source.StreamSource[Submis
             json_data["last_keys"]
         )
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "last_keys": self.last_keys,

--- a/hallo/modules/subscriptions/source_fa_favs.py
+++ b/hallo/modules/subscriptions/source_fa_favs.py
@@ -1,4 +1,4 @@
-from typing import Optional, NewType
+from typing import NewType
 
 import hallo.modules.subscriptions.subscription_exception
 from hallo.destination import Channel, User, Destination
@@ -54,7 +54,7 @@ class FAFavsSource(hallo.modules.subscriptions.stream_source.StreamSource[Submis
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
             username: str,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(last_keys)
         self.username = username
@@ -66,8 +66,8 @@ class FAFavsSource(hallo.modules.subscriptions.stream_source.StreamSource[Submis
     def item_to_event(
             self,
             server: Server,
-            channel: Optional[Channel],
-            user: Optional[User],
+            channel: Channel | None,
+            user: User | None,
             item: SubmissionId
     ) -> EventMessage:
         fa_reader = self.fa_key.get_fa_reader()

--- a/hallo/modules/subscriptions/source_fa_notes.py
+++ b/hallo/modules/subscriptions/source_fa_notes.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Optional
 
 from hallo.destination import Destination, Channel, User
 from hallo.events import EventMessage
@@ -20,12 +20,12 @@ class FANotesInboxSource(
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
 
-    def current_state(self) -> List[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANote]:
+    def current_state(self) -> list[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANote]:
         fa_reader = self.fa_key.get_fa_reader()
         return fa_reader.get_notes_page(hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.NOTES_INBOX).notes
 
@@ -63,14 +63,14 @@ class FANotesInboxSource(
         return FANotesInboxSource(fa_key)
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FANotesInboxSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FANotesInboxSource':
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
             json_data["fa_key_user_address"],
             destination.server, sub_repo
         )
         return FANotesInboxSource(fa_key, json_data["last_keys"])
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,
@@ -86,12 +86,12 @@ class FANotesOutboxSource(hallo.modules.subscriptions.stream_source.StreamSource
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
 
-    def current_state(self) -> List[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANote]:
+    def current_state(self) -> list[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANote]:
         fa_reader = self.fa_key.get_fa_reader()
         return [
             note for note in
@@ -130,14 +130,14 @@ class FANotesOutboxSource(hallo.modules.subscriptions.stream_source.StreamSource
         return FANotesOutboxSource(fa_key)
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FANotesOutboxSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FANotesOutboxSource':
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
             json_data["fa_key_user_address"],
             destination.server, sub_repo
         )
         return FANotesOutboxSource(fa_key, json_data["last_keys"])
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,
@@ -145,9 +145,9 @@ class FANotesOutboxSource(hallo.modules.subscriptions.stream_source.StreamSource
         }
 
 
-class FANotesSource(hallo.modules.subscriptions.source.Source[Dict, Dict]):
+class FANotesSource(hallo.modules.subscriptions.source.Source[dict, dict]):
     type_name: str = "fa_notif_notes"
-    type_names: List[str] = ["fa notes notifications", "fa notes", "furaffinity notes"]
+    type_names: list[str] = ["fa notes notifications", "fa notes", "furaffinity notes"]
 
     def __init__(self, fa_key: hallo.modules.subscriptions.common_fa_key.FAKey, inbox_source: FANotesInboxSource,
                  outbox_source: FANotesOutboxSource):
@@ -170,13 +170,13 @@ class FANotesSource(hallo.modules.subscriptions.source.Source[Dict, Dict]):
         outbox_source = FANotesOutboxSource(fa_key)
         return FANotesSource(fa_key, inbox_source, outbox_source)
 
-    def current_state(self) -> Dict:
+    def current_state(self) -> dict:
         return {
             "inbox": self.inbox_source.current_state(),
             "outbox": self.outbox_source.current_state()
         }
 
-    def state_change(self, state: Dict) -> Optional[Dict]:
+    def state_change(self, state: dict) -> Optional[dict]:
         inbox_change = self.inbox_source.state_change(state["inbox"])
         outbox_change = self.outbox_source.state_change(state["outbox"])
         if not inbox_change and not outbox_change:
@@ -186,20 +186,20 @@ class FANotesSource(hallo.modules.subscriptions.source.Source[Dict, Dict]):
             "outbox": outbox_change
         }
 
-    def save_state(self, state: Dict) -> None:
+    def save_state(self, state: dict) -> None:
         self.inbox_source.save_state(state["inbox"])
         self.outbox_source.save_state(state["outbox"])
 
     def events(
-            self, server: Server, channel: Optional[Channel], user: Optional[User], update: Dict
-    ) -> List[EventMessage]:
+            self, server: Server, channel: Optional[Channel], user: Optional[User], update: dict
+    ) -> list[EventMessage]:
         return (
                 self.inbox_source.events(server, channel, user, update["inbox"])
                 + self.outbox_source.events(server, channel, user, update["outbox"])
         )
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FANotesSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FANotesSource':
         # Load fa_key
         user_addr = json_data["fa_key_user_address"]
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
@@ -209,7 +209,7 @@ class FANotesSource(hallo.modules.subscriptions.source.Source[Dict, Dict]):
         outbox_source = FANotesOutboxSource.from_json(json_data["outbox"], destination, sub_repo)
         return FANotesSource(fa_key, inbox_source, outbox_source)
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         json_data = {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,

--- a/hallo/modules/subscriptions/source_fa_notes.py
+++ b/hallo/modules/subscriptions/source_fa_notes.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from hallo.destination import Destination, Channel, User
 from hallo.events import EventMessage
 import hallo.modules.subscriptions.source_fa_favs
@@ -20,7 +18,7 @@ class FANotesInboxSource(
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
@@ -38,8 +36,8 @@ class FANotesInboxSource(
     def item_to_event(
             self,
             server: Server,
-            channel: Optional[Channel],
-            user: Optional[User],
+            channel: Channel | None,
+            user: User | None,
             item: hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANote
     ) -> EventMessage:
         return EventMessage(
@@ -86,7 +84,7 @@ class FANotesOutboxSource(hallo.modules.subscriptions.stream_source.StreamSource
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
@@ -108,8 +106,8 @@ class FANotesOutboxSource(hallo.modules.subscriptions.stream_source.StreamSource
     def item_to_event(
             self,
             server: Server,
-            channel: Optional[Channel],
-            user: Optional[User],
+            channel: Channel | None,
+            user: User | None,
             item: hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANote
     ) -> EventMessage:
         return EventMessage(
@@ -176,7 +174,7 @@ class FANotesSource(hallo.modules.subscriptions.source.Source[dict, dict]):
             "outbox": self.outbox_source.current_state()
         }
 
-    def state_change(self, state: dict) -> Optional[dict]:
+    def state_change(self, state: dict) -> dict | None:
         inbox_change = self.inbox_source.state_change(state["inbox"])
         outbox_change = self.outbox_source.state_change(state["outbox"])
         if not inbox_change and not outbox_change:
@@ -191,7 +189,7 @@ class FANotesSource(hallo.modules.subscriptions.source.Source[dict, dict]):
         self.outbox_source.save_state(state["outbox"])
 
     def events(
-            self, server: Server, channel: Optional[Channel], user: Optional[User], update: dict
+            self, server: Server, channel: Channel | None, user: User | None, update: dict
     ) -> list[EventMessage]:
         return (
                 self.inbox_source.events(server, channel, user, update["inbox"])

--- a/hallo/modules/subscriptions/source_fa_notif_comments.py
+++ b/hallo/modules/subscriptions/source_fa_notif_comments.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Optional
 from urllib.error import HTTPError
 
 from hallo.destination import Destination, User, Channel
@@ -21,14 +21,14 @@ class FASubmissionCommentSource(
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
 
     def current_state(
             self
-    ) -> List[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationCommentSubmission]:
+    ) -> list[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationCommentSubmission]:
         notif_page = self.fa_key.get_fa_reader().get_notification_page()
         return notif_page.submission_comments
 
@@ -78,13 +78,13 @@ class FASubmissionCommentSource(
         return FASubmissionCommentSource(fa_key)
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FASubmissionCommentSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FASubmissionCommentSource':
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
             json_data["fa_key_user_address"], destination.server, sub_repo
         )
         return FASubmissionCommentSource(fa_key, json_data["last_keys"])
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,
@@ -103,14 +103,14 @@ class FAJournalCommentSource(
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
 
     def current_state(
             self
-    ) -> List[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationCommentJournal]:
+    ) -> list[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationCommentJournal]:
         notif_page = self.fa_key.get_fa_reader().get_notification_page()
         return notif_page.journal_comments
 
@@ -161,13 +161,13 @@ class FAJournalCommentSource(
         return FAJournalCommentSource(fa_key)
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FAJournalCommentSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FAJournalCommentSource':
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
             json_data["fa_key_user_address"], destination.server, sub_repo
         )
         return FAJournalCommentSource(fa_key, json_data["last_keys"])
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,
@@ -185,12 +185,12 @@ class FAShoutSource(
 
     def __init__(
             self, fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
 
-    def current_state(self) -> List[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationShout]:
+    def current_state(self) -> list[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationShout]:
         notif_page = self.fa_key.get_fa_reader().get_notification_page()
         return notif_page.shouts
 
@@ -247,14 +247,14 @@ class FAShoutSource(
         return FAShoutSource(fa_key)
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FAShoutSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FAShoutSource':
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
             json_data["fa_key_user_address"],
             destination.server, sub_repo
         )
         return FAShoutSource(fa_key, json_data["last_keys"])
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,
@@ -262,9 +262,9 @@ class FAShoutSource(
         }
 
 
-class FACommentNotificationsSource(hallo.modules.subscriptions.source.Source[Dict, Dict]):
+class FACommentNotificationsSource(hallo.modules.subscriptions.source.Source[dict, dict]):
     type_name: str = "fa_notif_comments"
-    type_names: List[str] = [
+    type_names: list[str] = [
         "{}{}{}".format(fa, comments, notifications)
         for fa in ["fa ", "furaffinity "]
         for comments in ["comments", "comment", "shouts", "shout"]
@@ -299,14 +299,14 @@ class FACommentNotificationsSource(hallo.modules.subscriptions.source.Source[Dic
         shout_source = FAShoutSource(fa_key)
         return FACommentNotificationsSource(fa_key, submission_source, journal_source, shout_source)
 
-    def current_state(self) -> Dict:
+    def current_state(self) -> dict:
         return {
             "submissions": self.submission_source.current_state(),
             "journals": self.journal_source.current_state(),
             "shouts": self.shout_source.current_state()
         }
 
-    def state_change(self, state: Dict) -> Optional[Dict]:
+    def state_change(self, state: dict) -> Optional[dict]:
         submission_update = self.submission_source.state_change(state["submissions"])
         journal_update = self.journal_source.state_change(state["journals"])
         shout_update = self.shout_source.state_change(state["shouts"])
@@ -318,14 +318,14 @@ class FACommentNotificationsSource(hallo.modules.subscriptions.source.Source[Dic
             "shouts": shout_update
         }
 
-    def save_state(self, state: Dict) -> None:
+    def save_state(self, state: dict) -> None:
         self.submission_source.save_state(state["submissions"])
         self.journal_source.save_state(state["journals"])
         self.shout_source.save_state(state["shouts"])
 
     def events(
-            self, server: Server, channel: Optional[Channel], user: Optional[User], update: Dict
-    ) -> List[EventMessage]:
+            self, server: Server, channel: Optional[Channel], user: Optional[User], update: dict
+    ) -> list[EventMessage]:
         return (
                 self.submission_source.events(server, channel, user, update["submissions"])
                 + self.journal_source.events(server, channel, user, update["journals"])
@@ -333,7 +333,7 @@ class FACommentNotificationsSource(hallo.modules.subscriptions.source.Source[Dic
         )
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FACommentNotificationsSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FACommentNotificationsSource':
         user_addr = json_data["fa_key_user_address"]
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
             user_addr, destination.server,
@@ -344,7 +344,7 @@ class FACommentNotificationsSource(hallo.modules.subscriptions.source.Source[Dic
         shout_source = FAShoutSource.from_json(json_data["shouts"], destination, sub_repo)
         return FACommentNotificationsSource(fa_key, submission_source, journal_source, shout_source)
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         json_data = {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,

--- a/hallo/modules/subscriptions/source_fa_notif_comments.py
+++ b/hallo/modules/subscriptions/source_fa_notif_comments.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from urllib.error import HTTPError
 
 from hallo.destination import Destination, User, Channel
@@ -21,7 +20,7 @@ class FASubmissionCommentSource(
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
@@ -38,7 +37,7 @@ class FASubmissionCommentSource(
         return item.comment_id
 
     def item_to_event(
-            self, server: Server, channel: Optional[Channel], user: Optional[User],
+            self, server: Server, channel: Channel | None, user: User | None,
             item: hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationCommentSubmission
     ) -> EventMessage:
         fa_reader = self.fa_key.get_fa_reader()
@@ -103,7 +102,7 @@ class FAJournalCommentSource(
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
@@ -121,7 +120,7 @@ class FAJournalCommentSource(
         return item.comment_id
 
     def item_to_event(
-            self, server: Server, channel: Optional[Channel], user: Optional[User],
+            self, server: Server, channel: Channel | None, user: User | None,
             item: hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationCommentJournal
     ) -> EventMessage:
         fa_reader = self.fa_key.get_fa_reader()
@@ -185,7 +184,7 @@ class FAShoutSource(
 
     def __init__(
             self, fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
@@ -201,7 +200,7 @@ class FAShoutSource(
         return item.shout_id
 
     def item_to_event(
-            self, server: Server, channel: Optional[Channel], user: Optional[User],
+            self, server: Server, channel: Channel | None, user: User | None,
             item: hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationShout
     ) -> EventMessage:
         fa_reader = self.fa_key.get_fa_reader()
@@ -306,7 +305,7 @@ class FACommentNotificationsSource(hallo.modules.subscriptions.source.Source[dic
             "shouts": self.shout_source.current_state()
         }
 
-    def state_change(self, state: dict) -> Optional[dict]:
+    def state_change(self, state: dict) -> dict | None:
         submission_update = self.submission_source.state_change(state["submissions"])
         journal_update = self.journal_source.state_change(state["journals"])
         shout_update = self.shout_source.state_change(state["shouts"])
@@ -324,7 +323,7 @@ class FACommentNotificationsSource(hallo.modules.subscriptions.source.Source[dic
         self.shout_source.save_state(state["shouts"])
 
     def events(
-            self, server: Server, channel: Optional[Channel], user: Optional[User], update: dict
+            self, server: Server, channel: Channel | None, user: User | None, update: dict
     ) -> list[EventMessage]:
         return (
                 self.submission_source.events(server, channel, user, update["submissions"])

--- a/hallo/modules/subscriptions/source_fa_notif_favs.py
+++ b/hallo/modules/subscriptions/source_fa_notif_favs.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict
+from typing import Optional
 
 from hallo.destination import Destination, User, Channel
 from hallo.events import EventMessage
@@ -14,7 +14,7 @@ class FAFavNotificationsSource(
     ]
 ):
     type_name: str = "fa_notif_favs"
-    type_names: List[str] = [
+    type_names: list[str] = [
         "fa favs notifications",
         "fa favs",
         "furaffinity favs",
@@ -26,12 +26,12 @@ class FAFavNotificationsSource(
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
 
-    def current_state(self) -> List[
+    def current_state(self) -> list[
         hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationFavourite
     ]:
         fa_reader = self.fa_key.get_fa_reader()
@@ -67,13 +67,13 @@ class FAFavNotificationsSource(
         return FAFavNotificationsSource(fa_key)
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FAFavNotificationsSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FAFavNotificationsSource':
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
             json_data["fa_key_user_address"], destination.server, sub_repo
         )
         return FAFavNotificationsSource(fa_key, json_data["last_keys"])
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,

--- a/hallo/modules/subscriptions/source_fa_notif_favs.py
+++ b/hallo/modules/subscriptions/source_fa_notif_favs.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from hallo.destination import Destination, User, Channel
 from hallo.events import EventMessage
 import hallo.modules.subscriptions.source_fa_favs
@@ -26,7 +24,7 @@ class FAFavNotificationsSource(
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(last_keys)
         self.fa_key = fa_key
@@ -45,7 +43,7 @@ class FAFavNotificationsSource(
         return item.fav_id
 
     def item_to_event(
-            self, server: Server, channel: Optional[Channel], user: Optional[User],
+            self, server: Server, channel: Channel | None, user: User | None,
             item: hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FANotificationFavourite
     ) -> EventMessage:
         return EventMessage(

--- a/hallo/modules/subscriptions/source_fa_watchers.py
+++ b/hallo/modules/subscriptions/source_fa_watchers.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Optional
 
 import hallo.modules.subscriptions.subscription_exception
 from hallo.destination import Destination, User, Channel
@@ -15,7 +15,7 @@ class FAUserWatchersSource(
     ]
 ):
     type_name: str = "fa_user_watchers"
-    type_names: List[str] = [
+    type_names: list[str] = [
         "fa user watchers",
         "fa user new watchers",
         "furaffinity user watchers",
@@ -23,12 +23,12 @@ class FAUserWatchersSource(
     ]
 
     def __init__(self, fa_key: hallo.modules.subscriptions.common_fa_key.FAKey, username: str,
-                 last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None):
+                 last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None):
         super().__init__(last_keys)
         self.fa_key = fa_key
         self.username = username
 
-    def current_state(self) -> List[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FAWatch]:
+    def current_state(self) -> list[hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FAWatch]:
         fa_reader = self.fa_key.get_fa_reader()
         user_page = fa_reader.get_user_page(self.username)
         return user_page.watched_by
@@ -70,7 +70,7 @@ class FAUserWatchersSource(
         return FAUserWatchersSource(fa_key, argument)
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FAUserWatchersSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FAUserWatchersSource':
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
             json_data["fa_key_user_address"],
             destination.server, sub_repo
@@ -81,7 +81,7 @@ class FAUserWatchersSource(
             json_data["last_keys"]
         )
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,
@@ -92,7 +92,7 @@ class FAUserWatchersSource(
 
 class FAWatchersSource(FAUserWatchersSource):
     type_name: str = "fa_notif_watchers"
-    type_names: List[str] = [
+    type_names: list[str] = [
         "{}{}{}{}".format(fa, new, watchers, notifications)
         for fa in ["fa ", "furaffinity "]
         for new in ["new ", ""]
@@ -103,7 +103,7 @@ class FAWatchersSource(FAUserWatchersSource):
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         username = fa_key.get_fa_reader().get_notification_page().username
         super().__init__(fa_key, username, last_keys)
@@ -121,14 +121,14 @@ class FAWatchersSource(FAUserWatchersSource):
         return FAWatchersSource(fa_key)
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'FAWatchersSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'FAWatchersSource':
         fa_key = hallo.modules.subscriptions.source_fa_favs.fa_key_from_json(
             json_data["fa_key_user_address"],
             destination.server, sub_repo
         )
         return FAWatchersSource(fa_key, json_data["last_keys"])
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "fa_key_user_address": self.fa_key.user.address,

--- a/hallo/modules/subscriptions/source_fa_watchers.py
+++ b/hallo/modules/subscriptions/source_fa_watchers.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import hallo.modules.subscriptions.subscription_exception
 from hallo.destination import Destination, User, Channel
 from hallo.events import EventMessage
@@ -23,7 +21,7 @@ class FAUserWatchersSource(
     ]
 
     def __init__(self, fa_key: hallo.modules.subscriptions.common_fa_key.FAKey, username: str,
-                 last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None):
+                 last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None):
         super().__init__(last_keys)
         self.fa_key = fa_key
         self.username = username
@@ -40,7 +38,7 @@ class FAUserWatchersSource(
         return item.watcher_username
 
     def item_to_event(
-            self, server: Server, channel: Optional[Channel], user: Optional[User],
+            self, server: Server, channel: Channel | None, user: User | None,
             item: hallo.modules.subscriptions.common_fa_key.FAKey.FAReader.FAWatch
     ) -> EventMessage:
         link = "https://furaffinity.net/user/{}/".format(item.watcher_username)
@@ -103,7 +101,7 @@ class FAWatchersSource(FAUserWatchersSource):
     def __init__(
             self,
             fa_key: hallo.modules.subscriptions.common_fa_key.FAKey,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         username = fa_key.get_fa_reader().get_notification_page().username
         super().__init__(fa_key, username, last_keys)

--- a/hallo/modules/subscriptions/source_rss.py
+++ b/hallo/modules/subscriptions/source_rss.py
@@ -1,6 +1,5 @@
 import hashlib
 import re
-from typing import Optional
 from xml.etree import ElementTree
 
 from bs4 import BeautifulSoup
@@ -12,7 +11,7 @@ import hallo.modules.subscriptions.stream_source
 from hallo.server import Server
 
 
-def _get_item_title(feed_item: ElementTree.Element) -> Optional[str]:
+def _get_item_title(feed_item: ElementTree.Element) -> str | None:
     title_elem = feed_item.find("title")
     if title_elem is not None:
         return title_elem.text
@@ -44,8 +43,8 @@ class RssSource(hallo.modules.subscriptions.stream_source.StreamSource[ElementTr
     def __init__(
             self,
             url: str,
-            feed_title: Optional[str] = None,
-            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
+            feed_title: str | None = None,
+            last_keys: list[hallo.modules.subscriptions.stream_source.Key] | None = None
     ):
         super().__init__(last_keys)
         self.url = url
@@ -105,7 +104,7 @@ class RssSource(hallo.modules.subscriptions.stream_source.StreamSource[ElementTr
         return item_hash
 
     def item_to_event(
-            self, server: Server, channel: Optional[Channel], user: Optional[User],
+            self, server: Server, channel: Channel | None, user: User | None,
             item: ElementTree.Element
     ) -> EventMessage:
         # Check custom formatting
@@ -121,9 +120,9 @@ class RssSource(hallo.modules.subscriptions.stream_source.StreamSource[ElementTr
         return output_evt
 
     def _format_custom_sites(
-            self, server: Server, channel: Optional[Channel], user: Optional[User],
+            self, server: Server, channel: Channel | None, user: User | None,
             item: ElementTree.Element
-    ) -> Optional[EventMessage]:
+    ) -> EventMessage | None:
         if "xkcd.com" in self.url:
             item_title = item.find("title").text
             item_link = item.find("link").text

--- a/hallo/modules/subscriptions/source_rss.py
+++ b/hallo/modules/subscriptions/source_rss.py
@@ -1,6 +1,6 @@
 import hashlib
 import re
-from typing import List, Dict, Optional
+from typing import Optional
 from xml.etree import ElementTree
 
 from bs4 import BeautifulSoup
@@ -29,7 +29,7 @@ def get_rss_item_link(feed_item: ElementTree.Element) -> str:
     return feed_item.find("{http://www.w3.org/2005/Atom}link").get("href")
 
 
-def _get_feed_items(rss_elem: ElementTree.Element) -> List[ElementTree.Element]:
+def _get_feed_items(rss_elem: ElementTree.Element) -> list[ElementTree.Element]:
     channel_elem = rss_elem.find("channel")
     if channel_elem is not None:
         return channel_elem.findall("item")
@@ -39,13 +39,13 @@ def _get_feed_items(rss_elem: ElementTree.Element) -> List[ElementTree.Element]:
 
 class RssSource(hallo.modules.subscriptions.stream_source.StreamSource[ElementTree.Element]):
     type_name: str = "rss"
-    type_names: List[str] = ["rss", "rss feed"]
+    type_names: list[str] = ["rss", "rss feed"]
 
     def __init__(
             self,
             url: str,
             feed_title: Optional[str] = None,
-            last_keys: Optional[List[hallo.modules.subscriptions.stream_source.Key]] = None
+            last_keys: Optional[list[hallo.modules.subscriptions.stream_source.Key]] = None
     ):
         super().__init__(last_keys)
         self.url = url
@@ -84,7 +84,7 @@ class RssSource(hallo.modules.subscriptions.stream_source.StreamSource[ElementTr
             rss_data = rss_data[2:]
         return rss_data
 
-    def current_state(self) -> List[ElementTree.Element]:
+    def current_state(self) -> list[ElementTree.Element]:
         rss_data = self.get_rss_data()
         rss_elem = ElementTree.fromstring(rss_data)
         # Update title
@@ -195,14 +195,14 @@ class RssSource(hallo.modules.subscriptions.stream_source.StreamSource[ElementTr
         return RssSource(argument)
 
     @classmethod
-    def from_json(cls, json_data: Dict, destination: Destination, sub_repo) -> 'RssSource':
+    def from_json(cls, json_data: dict, destination: Destination, sub_repo) -> 'RssSource':
         return RssSource(
             json_data["url"],
             json_data["title"],
             json_data["last_keys"]
         )
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         return {
             "type": self.type_name,
             "url": self.url,

--- a/hallo/modules/subscriptions/stream_source.py
+++ b/hallo/modules/subscriptions/stream_source.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TypeVar, Union, List, Generic, Optional
+from typing import TypeVar, Union, Generic, Optional
 
 from hallo.destination import Channel, User
 from hallo.events import EventMessage
@@ -10,16 +10,16 @@ Item = TypeVar("Item")
 Key = Union[str, int]
 
 
-class StreamSource(hallo.modules.subscriptions.source.Source[List[Item], List[Item]], Generic[Item]):
-    def __init__(self, last_keys: Optional[List[Key]]):
+class StreamSource(hallo.modules.subscriptions.source.Source[list[Item], list[Item]], Generic[Item]):
+    def __init__(self, last_keys: Optional[list[Key]]):
         super().__init__()
-        self.last_keys: List[Key] = last_keys or []
+        self.last_keys: list[Key] = last_keys or []
 
     @abstractmethod
-    def current_state(self) -> List[Item]:
+    def current_state(self) -> list[Item]:
         pass
 
-    def state_change(self, state: List[Item]) -> List[Item]:
+    def state_change(self, state: list[Item]) -> list[Item]:
         # If no last keys, All state is update
         if not self.last_keys:
             return state
@@ -38,7 +38,7 @@ class StreamSource(hallo.modules.subscriptions.source.Source[List[Item], List[It
             new_items += batch
         return new_items
 
-    def save_state(self, state: List[Item]) -> None:
+    def save_state(self, state: list[Item]) -> None:
         self.last_keys = [self.item_to_key(item) for item in state]
 
     def events(
@@ -46,8 +46,8 @@ class StreamSource(hallo.modules.subscriptions.source.Source[List[Item], List[It
             server: Server,
             channel: Optional[Channel],
             user: Optional[User],
-            update: List[Item]
-    ) -> List[EventMessage]:
+            update: list[Item]
+    ) -> list[EventMessage]:
         return [self.item_to_event(server, channel, user, item) for item in update[::-1]]
 
     @abstractmethod

--- a/hallo/modules/subscriptions/stream_source.py
+++ b/hallo/modules/subscriptions/stream_source.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TypeVar, Union, Generic
+from typing import TypeVar, Generic
 
 from hallo.destination import Channel, User
 from hallo.events import EventMessage
@@ -7,7 +7,7 @@ import hallo.modules.subscriptions.source
 from hallo.server import Server
 
 Item = TypeVar("Item")
-Key = Union[str, int]
+Key = str | int
 
 
 class StreamSource(hallo.modules.subscriptions.source.Source[list[Item], list[Item]], Generic[Item]):

--- a/hallo/modules/subscriptions/stream_source.py
+++ b/hallo/modules/subscriptions/stream_source.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TypeVar, Union, Generic, Optional
+from typing import TypeVar, Union, Generic
 
 from hallo.destination import Channel, User
 from hallo.events import EventMessage
@@ -11,7 +11,7 @@ Key = Union[str, int]
 
 
 class StreamSource(hallo.modules.subscriptions.source.Source[list[Item], list[Item]], Generic[Item]):
-    def __init__(self, last_keys: Optional[list[Key]]):
+    def __init__(self, last_keys: list[Key] | None):
         super().__init__()
         self.last_keys: list[Key] = last_keys or []
 
@@ -44,8 +44,8 @@ class StreamSource(hallo.modules.subscriptions.source.Source[list[Item], list[It
     def events(
             self,
             server: Server,
-            channel: Optional[Channel],
-            user: Optional[User],
+            channel: Channel | None,
+            user: User | None,
             update: list[Item]
     ) -> list[EventMessage]:
         return [self.item_to_event(server, channel, user, item) for item in update[::-1]]
@@ -58,8 +58,8 @@ class StreamSource(hallo.modules.subscriptions.source.Source[list[Item], list[It
     def item_to_event(
             self,
             server: Server,
-            channel: Optional[Channel],
-            user: Optional[User],
+            channel: Channel | None,
+            user: User | None,
             item: Item
     ) -> EventMessage:
         pass

--- a/hallo/modules/subscriptions/subscription.py
+++ b/hallo/modules/subscriptions/subscription.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import timedelta, datetime
-from typing import Dict, Optional, Type
+from typing import Type
 
 import dateutil.parser
 import isodate
@@ -24,15 +24,15 @@ class Subscription:
             destination: Destination,
             source: 'hallo.modules.subscriptions.source.Source',
             period: timedelta,
-            last_check: Optional[datetime],
-            last_update: Optional[datetime]
+            last_check: datetime | None,
+            last_update: datetime | None
     ):
         self.server: Server = server
         self.destination: Destination = destination
         self.source: hallo.modules.subscriptions.source.Source = source
         self.period: timedelta = period
-        self.last_check: Optional[datetime] = last_check
-        self.last_update: Optional[datetime] = last_update
+        self.last_check: datetime | None = last_check
+        self.last_update: datetime | None = last_update
 
     @classmethod
     def create_from_input(
@@ -120,7 +120,7 @@ class Subscription:
         return self.source.passive_run(event, hallo_obj)
 
     @classmethod
-    def from_json(cls, json_data: Dict, hallo_obj: Hallo, sub_repo) -> 'Subscription':
+    def from_json(cls, json_data: dict, hallo_obj: Hallo, sub_repo) -> 'Subscription':
         server = hallo_obj.get_server_by_name(json_data["server_name"])
         if server is None:
             raise hallo.modules.subscriptions.subscription_exception.SubscriptionException(
@@ -164,7 +164,7 @@ class Subscription:
         )
         return subscription
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         json_data = dict()
         json_data["server_name"] = self.server.name
         if isinstance(self.destination, Channel):

--- a/hallo/modules/subscriptions/subscription_check.py
+++ b/hallo/modules/subscriptions/subscription_check.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Set, Type, Optional
+from typing import Type
 
 from hallo.errors import SubscriptionCheckError
 from hallo.events import Event, EventMinute, EventMessage, ServerEvent, EventMenuCallback
@@ -77,7 +77,7 @@ class SubscriptionCheck(Function):
         if self.subscription_repo is not None:
             self.subscription_repo.save_json()
 
-    def get_passive_events(self) -> Set[Type[Event]]:
+    def get_passive_events(self) -> set[Type[Event]]:
         """Returns a list of events which this function may want to respond to in a passive way"""
         return {EventMinute, EventMenuCallback, EventMessage}
 
@@ -116,7 +116,7 @@ class SubscriptionCheck(Function):
             f"Subscription updates were found."
         )
 
-    def passive_run(self, event: Event, hallo_obj: Hallo) -> Optional[ServerEvent]:
+    def passive_run(self, event: Event, hallo_obj: Hallo) -> ServerEvent | None:
         if isinstance(event, EventMenuCallback):
             sub_repo = self.get_sub_repo(hallo_obj)
             sub_repo.handle_menu_callback(event)

--- a/hallo/modules/subscriptions/subscription_common.py
+++ b/hallo/modules/subscriptions/subscription_common.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Optional, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from hallo.hallo import Hallo
@@ -11,9 +11,9 @@ class SubscriptionCommon(ABC):
     def __init__(self, hallo_obj: 'Hallo'):
         self.hallo = hallo_obj
 
-    def to_json(self) -> Optional[Dict]:
+    def to_json(self) -> dict | None:
         raise NotImplementedError()
 
     @staticmethod
-    def from_json(json_obj: Optional[Dict], hallo_obj: 'Hallo') -> 'SubscriptionCommon':
+    def from_json(json_obj: dict | None, hallo_obj: 'Hallo') -> 'SubscriptionCommon':
         raise NotImplementedError()

--- a/hallo/modules/subscriptions/subscription_factory.py
+++ b/hallo/modules/subscriptions/subscription_factory.py
@@ -1,4 +1,4 @@
-from typing import List, Type, Dict, TYPE_CHECKING
+from typing import Type, TYPE_CHECKING
 
 import hallo.modules.subscriptions.subscription_exception
 from hallo.destination import Destination
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class SubscriptionFactory:
-    sub_sources: List[Type['hallo.modules.new_subscriptions.source.Source']] = [
+    sub_sources: list[Type['hallo.modules.new_subscriptions.source.Source']] = [
         hallo.modules.subscriptions.source_e621.E621Source,
         hallo.modules.subscriptions.source_e621_tagging.E621TaggingSource,
         hallo.modules.subscriptions.source_e621_backlog.E621BacklogTaggingSource,
@@ -33,12 +33,12 @@ class SubscriptionFactory:
         hallo.modules.subscriptions.source_fa_watchers.FAUserWatchersSource,
         hallo.modules.subscriptions.source_rss.RssSource,
     ]
-    common_classes: List[Type[hallo.modules.subscriptions.subscription_common.SubscriptionCommon]] = [
+    common_classes: list[Type[hallo.modules.subscriptions.subscription_common.SubscriptionCommon]] = [
         hallo.modules.subscriptions.common_fa_key.FAKeysCommon
     ]
 
     @staticmethod
-    def get_source_names() -> List[str]:
+    def get_source_names() -> list[str]:
         return [
             name
             for sub_class in SubscriptionFactory.sub_sources
@@ -60,7 +60,7 @@ class SubscriptionFactory:
 
     @staticmethod
     def source_from_json(
-            json_data: Dict,
+            json_data: dict,
             destination: Destination,
             sub_repo
     ) -> 'hallo.modules.new_subscriptions.source.Source':
@@ -78,7 +78,7 @@ class SubscriptionFactory:
 
     @staticmethod
     def common_from_json(
-            common_json: Dict,
+            common_json: dict,
             hallo_obj: 'Hallo'
     ) -> hallo.modules.subscriptions.subscription_common.SubscriptionCommon:
         common_type_name = common_json["common_type"]

--- a/hallo/modules/subscriptions/subscription_list.py
+++ b/hallo/modules/subscriptions/subscription_list.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from hallo.events import EventMessage
 from hallo.function import Function
 import hallo.modules.subscriptions.subscription_factory
@@ -61,7 +59,7 @@ class SubscriptionList(Function):
         sub_repo = sub_check_obj.get_sub_repo(hallo_obj)
         # Find list of feeds for current channel.
         with sub_repo.sub_lock:
-            dest_searches: List[hallo.modules.subscriptions.subscription.Subscription] = \
+            dest_searches: list[hallo.modules.subscriptions.subscription.Subscription] = \
                 sub_repo.get_subs_by_destination(event.destination)
         if len(dest_searches) == 0:
             return event.create_response(

--- a/hallo/modules/subscriptions/subscription_remove.py
+++ b/hallo/modules/subscriptions/subscription_remove.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from hallo.events import EventMessage
 from hallo.function import Function
 import hallo.modules.subscriptions.subscription_factory
@@ -66,7 +64,7 @@ class SubscriptionRemove(Function):
         # Acquire lock
         with sub_repo.sub_lock:
             # Find any feeds with specified title
-            test_subs: List[hallo.modules.subscriptions.subscription.Subscription] = sub_repo.get_subs_by_name(
+            test_subs: list[hallo.modules.subscriptions.subscription.Subscription] = sub_repo.get_subs_by_name(
                 clean_input.lower(),
                 event.destination,
             )

--- a/hallo/modules/subscriptions/subscription_repo.py
+++ b/hallo/modules/subscriptions/subscription_repo.py
@@ -1,6 +1,6 @@
 import json
 from threading import Lock
-from typing import List, Type, TypeVar, TYPE_CHECKING
+from typing import Type, TypeVar, TYPE_CHECKING
 
 import hallo.modules.subscriptions.subscription
 import hallo.modules.subscriptions.subscription_common
@@ -29,8 +29,8 @@ class SubscriptionRepo:
 
     def __init__(self, hallo_obj: 'Hallo'):
         self.hallo = hallo_obj
-        self.sub_list: List[hallo.modules.subscriptions.subscription.Subscription] = []
-        self.common_list: List[hallo.modules.subscriptions.subscription_common.SubscriptionCommon] = []
+        self.sub_list: list[hallo.modules.subscriptions.subscription.Subscription] = []
+        self.common_list: list[hallo.modules.subscriptions.subscription_common.SubscriptionCommon] = []
         self.sub_lock: Lock = Lock()
         self.menu_cache = None
         for sub_class in hallo.modules.subscriptions.subscription_factory.SubscriptionFactory.sub_sources:
@@ -55,7 +55,7 @@ class SubscriptionRepo:
 
     def get_subs_by_destination(
             self, destination: Destination
-    ) -> List[hallo.modules.subscriptions.subscription.Subscription]:
+    ) -> list[hallo.modules.subscriptions.subscription.Subscription]:
         """
         Returns a list of subscriptions matching a specified destination.
         :param destination: Channel or User which E621Sub is posting to
@@ -70,7 +70,7 @@ class SubscriptionRepo:
 
     def get_subs_by_name(
             self, name: str, destination: Destination
-    ) -> List[hallo.modules.subscriptions.subscription.Subscription]:
+    ) -> list[hallo.modules.subscriptions.subscription.Subscription]:
         """
         Returns a list of subscriptions matching a specified name, be that a type and search, or just a type
         :param name: Search of the Subscription being searched for

--- a/hallo/modules/user_data.py
+++ b/hallo/modules/user_data.py
@@ -1,6 +1,6 @@
 import re
 from abc import ABCMeta
-from typing import TypeVar, Type, Optional
+from typing import TypeVar, Type
 
 from hallo.destination import User
 from hallo.function import Function
@@ -49,7 +49,7 @@ class UserDataParser:
             user_data[key] = UserDataFactory.from_dict(key, user_data_dict[key])
         return user_data
 
-    def get_data_by_user_and_type(self, user: User, data_class: Type[T]) -> Optional[T]:
+    def get_data_by_user_and_type(self, user: User, data_class: Type[T]) -> T | None:
         type_name = data_class.type_name
         user_data_dict = user.extra_data_dict
         if type_name in user_data_dict:

--- a/hallo/modules/user_data.py
+++ b/hallo/modules/user_data.py
@@ -1,6 +1,6 @@
 import re
 from abc import ABCMeta
-from typing import Dict, TypeVar, Type, Optional, List
+from typing import TypeVar, Type, Optional
 
 from hallo.destination import User
 from hallo.function import Function
@@ -42,7 +42,7 @@ class UserDataParser:
     def __init__(self):
         pass
 
-    def get_data_by_user(self, user: User) -> Dict[str, 'UserDatum']:
+    def get_data_by_user(self, user: User) -> dict[str, 'UserDatum']:
         user_data_dict = user.extra_data_dict
         user_data = dict()
         for key in user_data_dict:
@@ -259,7 +259,7 @@ class UserDataFactory:
     data_classes = [FAKeyData, E6KeyData]
 
     @staticmethod
-    def get_data_type_names() -> List[str]:
+    def get_data_type_names() -> list[str]:
         return [
             name
             for common_class in UserDataFactory.data_classes

--- a/hallo/permission_mask.py
+++ b/hallo/permission_mask.py
@@ -1,4 +1,4 @@
-class PermissionMask(object):
+class PermissionMask:
     """
     Permission mask object, stores which rights are enabled or disabled by level
     """
@@ -8,7 +8,7 @@ class PermissionMask(object):
     def __init__(self):
         self.rights_map = {}
 
-    def get_right(self, right):
+    def get_right(self, right: str) -> None | bool:
         """
         Gets the value of the specified right in the rights map
         :param right: Name of the right to be searching for
@@ -17,7 +17,7 @@ class PermissionMask(object):
             return self.rights_map[right]
         return None
 
-    def set_right(self, right, value):
+    def set_right(self, right: str, value: None | bool | str) -> None:
         """Sets the value of the specified right in the rights map
         :param right: Name of the right to set
         :param value: Value to set the right to
@@ -35,11 +35,11 @@ class PermissionMask(object):
         if value in [True, False]:
             self.rights_map[right] = value
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """Returns a boolean representing whether the PermissionMask is "empty" or has no rights set."""
         return len(self.rights_map) == 0
 
-    def to_json(self):
+    def to_json(self) -> dict:
         """
         Returns the PermissionMask configuration as an object for serialisation into json
         :return: dict
@@ -52,7 +52,7 @@ class PermissionMask(object):
         return json_obj
 
     @staticmethod
-    def from_json(json_obj):
+    def from_json(json_obj: dict) -> "PermissionMask":
         new_mask = PermissionMask()
         for map_right in json_obj:
             new_mask.set_right(map_right, json_obj[map_right])

--- a/hallo/server.py
+++ b/hallo/server.py
@@ -106,7 +106,7 @@ class Server(metaclass=ABCMeta):
             self,
             event: 'ServerEvent',
             *,
-            after_sent_callback: Optional[Callable[['ServerEvent'], None]] = None
+            after_sent_callback: Callable[['ServerEvent'], None] | None = None
     ) -> None:
         """
         Sends a message to the server, or a specific channel in the server
@@ -237,7 +237,7 @@ class Server(metaclass=ABCMeta):
         """Returns boolean representing whether the server is connected or not."""
         return self.state == Server.STATE_OPEN
 
-    def get_channel_by_name(self, channel_name: str) -> Optional[Channel]:
+    def get_channel_by_name(self, channel_name: str) -> Channel | None:
         """
         Returns a Channel object with the specified channel name.
         :param channel_name: Name of the channel which is being searched for
@@ -299,7 +299,7 @@ class Server(metaclass=ABCMeta):
         # Set not in channel
         channel_obj.set_in_channel(False)
 
-    def get_user_by_name(self, user_name: str) -> Optional[User]:
+    def get_user_by_name(self, user_name: str) -> User | None:
         """
         Returns a User object with the specified user name.
         :param user_name: Name of user which is being searched for
@@ -311,7 +311,7 @@ class Server(metaclass=ABCMeta):
         # No user by that name exists, return None
         return None
 
-    def get_user_by_address(self, address: str, user_name: str = None) -> Optional[User]:
+    def get_user_by_address(self, address: str, user_name: str = None) -> User | None:
         """
         Returns a User object with the specified user name.
         :param address: address of the user which is being searched for or added

--- a/hallo/server.py
+++ b/hallo/server.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Optional, TYPE_CHECKING, Union, Dict, List, Callable
+from typing import Optional, TYPE_CHECKING, Union, Callable
 
 from prometheus_client import Counter
 
@@ -175,7 +175,7 @@ class Server(metaclass=ABCMeta):
     def edit_by_id(self, message_id: int, new_event: 'ChannelUserTextEvent', *, has_photo: bool = False):
         raise NotImplementedError
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         """
         Returns a dict formatted so it may be serialised into json configuration data
         """
@@ -327,7 +327,7 @@ class Server(metaclass=ABCMeta):
         self.add_user(new_user)
         return new_user
 
-    def get_user_list(self) -> List[User]:
+    def get_user_list(self) -> list[User]:
         """Returns the full list of users on this server."""
         return self.user_list
 

--- a/hallo/server.py
+++ b/hallo/server.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Optional, TYPE_CHECKING, Union, Callable
+from typing import Optional, TYPE_CHECKING, Callable
 
 from prometheus_client import Counter
 
@@ -194,13 +194,13 @@ class Server(metaclass=ABCMeta):
         """
         self.nick = nick
 
-    def get_prefix(self) -> Union[str, bool]:
+    def get_prefix(self) -> str | bool:
         """Prefix getter"""
         if self.prefix is None:
             return self.hallo.default_prefix
         return self.prefix
 
-    def set_prefix(self, prefix: Union[str, bool, None]) -> None:
+    def set_prefix(self, prefix: str | bool | None) -> None:
         """
         Prefix setter
         :param prefix: Prefix for hallo to use for function calls on this server

--- a/hallo/server_irc.py
+++ b/hallo/server_irc.py
@@ -3,7 +3,7 @@ import re
 import socket
 import time
 from threading import RLock, Lock, Thread
-from typing import Callable, Optional
+from typing import Callable
 
 from hallo.destination import ChannelMembership, Channel, User
 from hallo.errors import MessageError, ExceptionError
@@ -296,7 +296,7 @@ class ServerIRC(Server):
             self,
             event: 'ServerEvent',
             *,
-            after_sent_callback: Optional[Callable[['ServerEvent'], None]] = None
+            after_sent_callback: Callable[['ServerEvent'], None] | None = None
     ) -> None:
         self.outgoing.labels(
             server_type=self.__class__.__name__,

--- a/hallo/server_telegram.py
+++ b/hallo/server_telegram.py
@@ -1,5 +1,5 @@
 from threading import Lock, Thread
-from typing import Optional, TYPE_CHECKING, Dict, Callable
+from typing import TYPE_CHECKING, Callable
 
 import telegram
 from telegram import Chat, InputMediaPhoto, InlineKeyboardButton, InlineKeyboardMarkup, Update, Message, TelegramError
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def event_menu_for_telegram(event: EventMessage) -> Optional[InlineKeyboardMarkup]:
+def event_menu_for_telegram(event: EventMessage) -> InlineKeyboardMarkup | None:
     if not event.menu_buttons:
         return None
     menu = []
@@ -41,7 +41,7 @@ def event_menu_for_telegram(event: EventMessage) -> Optional[InlineKeyboardMarku
     return InlineKeyboardMarkup(menu)
 
 
-def formatting_to_telegram_mode(event_formatting: EventMessage.Formatting) -> Optional[str]:
+def formatting_to_telegram_mode(event_formatting: EventMessage.Formatting) -> str | None:
     return {
         EventMessage.Formatting.MARKDOWN: telegram.ParseMode.MARKDOWN,
         EventMessage.Formatting.HTML: telegram.ParseMode.HTML,
@@ -298,8 +298,8 @@ class ServerTelegram(Server):
             self,
             event: ServerEvent,
             *,
-            after_sent_callback: Optional[Callable[[ServerEvent], None]] = None,
-            reply_to_id: Optional[int] = None
+            after_sent_callback: Callable[[ServerEvent], None] | None = None,
+            reply_to_id: int | None = None
     ) -> None:
         is_group = False
         if isinstance(event, EventMessage):
@@ -319,8 +319,8 @@ class ServerTelegram(Server):
             self,
             event: ServerEvent,
             *,
-            after_sent_callback: Optional[Callable[[ServerEvent], None]] = None,
-            reply_to_id: Optional[int] = None
+            after_sent_callback: Callable[[ServerEvent], None] | None = None,
+            reply_to_id: int | None = None
     ) -> None:
         if isinstance(event, EventMessageWithPhoto):
             destination = event.destination
@@ -479,7 +479,7 @@ class ServerTelegram(Server):
         if chat.type in [chat.GROUP, chat.SUPERGROUP, chat.CHANNEL]:
             return chat.title
 
-    def to_json(self) -> Dict:
+    def to_json(self) -> dict:
         """
         Creates a dict of configuration for the server, to store as json
         """
@@ -503,7 +503,7 @@ class ServerTelegram(Server):
         return json_obj
 
     @staticmethod
-    def from_json(json_obj: Dict, hallo: 'Hallo') -> 'ServerTelegram':
+    def from_json(json_obj: dict, hallo: 'Hallo') -> 'ServerTelegram':
         api_key = json_obj["api_key"]
         new_server = ServerTelegram(hallo, api_key)
         new_server.name = json_obj["name"]

--- a/hallo/test/conftest.py
+++ b/hallo/test/conftest.py
@@ -1,6 +1,5 @@
 import time
 from threading import Thread
-from typing import Set, Optional
 
 import pytest
 
@@ -36,7 +35,7 @@ class TestHallo(Hallo):
         self._test_chan = None
         self._hallo_user = None
 
-    def set_modules(self, modules: Optional[Set[str]]):
+    def set_modules(self, modules: set[str] | None) -> None:
         modules = modules or DEFAULT_MODULES
         self.function_dispatcher = FunctionDispatcher(modules, self)
 
@@ -76,7 +75,7 @@ def hallo_getter():
     hallo = TestHallo()
     hallo_thread = Thread(target=hallo.start, )
 
-    def function(modules: Optional[Set[str]] = None, disconnect_servers: bool = False):
+    def function(modules: set[str] | None = None, disconnect_servers: bool = False):
         hallo.set_modules(modules)
         # Start hallo thread
         hallo_thread.start()

--- a/hallo/test/modules/subscriptions/test_all_source_types.py
+++ b/hallo/test/modules/subscriptions/test_all_source_types.py
@@ -1,7 +1,7 @@
 import importlib
 import inspect
 import os
-from typing import Dict, List, Type
+from typing import Type
 
 import pytest
 from yippi import YippiClient
@@ -32,7 +32,7 @@ def fa_key_from_env(test_user: User) -> FAKey:
 
 
 @pytest.fixture
-def source_objects(hallo_getter) -> List[Source]:
+def source_objects(hallo_getter) -> list[Source]:
     test_hallo = hallo_getter({"subscriptions"})
     fa_key = fa_key_from_env(test_hallo.test_user)
     e6_client = YippiClient("hallo_test", "0.1.0", "dr-spangle")
@@ -57,7 +57,7 @@ def source_objects(hallo_getter) -> List[Source]:
 
 
 @pytest.fixture
-def source_creation_arguments(hallo_getter) -> Dict[Type[Source], str]:
+def source_creation_arguments(hallo_getter) -> dict[Type[Source], str]:
     test_hallo = hallo_getter({"subscriptions"})
     sub_repo = SubscriptionRepo(test_hallo)
     fa_key = fa_key_from_env(test_hallo.test_user)


### PR DESCRIPTION
This PR does a whole bunch of commits to reduce imports from the `typing` module for things we don't need to import from there anymore. Stuff like `List`, `Dict`, `Set`, `Optional` (in most cases), `Union`, and such